### PR TITLE
[SC-100] Widok wyświetlający listę studentów przypisanych do grupy zajęciowej

### DIFF
--- a/frontend/src/components/general/PageGuard/PageGuard.js
+++ b/frontend/src/components/general/PageGuard/PageGuard.js
@@ -20,7 +20,7 @@ function PageGuard(props) {
       if ((role === Role.LOGGED_IN_AS_STUDENT || (role === Role.NOT_LOGGED_IN && isLoggedIn)) && !student) {
         navigate(generateFullPath(() => PageRoutes.Teacher.GameSummary.GAME_SUMMARY))
         window.location.reload(true) // without it, sidebar not reload after redirect
-      } else if ((role === Role.LOGGED_IS_AS_TEACHER || (role === Role.NOT_LOGGED_IN && isLoggedIn)) && student) {
+      } else if ((role === Role.LOGGED_IN_AS_TEACHER || (role === Role.NOT_LOGGED_IN && isLoggedIn)) && student) {
         navigate(generateFullPath(() => PageRoutes.Student.GameCard.GAME_CARD))
         window.location.reload(true) // without it, sidebar not reload after redirect
       }

--- a/frontend/src/components/professor/ParticipantsPage/Participants.js
+++ b/frontend/src/components/professor/ParticipantsPage/Participants.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Tab } from 'react-bootstrap'
+import { getAllParticipants, getGroups } from './mockData'
+import ParticipantsTable from './ParticipantsTable'
+import { ParticipantsContent, TabsContainer } from './ParticipantsStyles'
+
+function Participants() {
+  // TODO: get groups using endpoint
+  const groups = getGroups()
+  const allParticipants = getAllParticipants()
+
+  return (
+    <ParticipantsContent>
+      <TabsContainer defaultActiveKey={'all'}>
+        <Tab eventKey={'all'} title={'Wszyscy'}>
+          <ParticipantsTable data={allParticipants} />
+        </Tab>
+
+        {groups.map((group, index) => (
+          <Tab key={index + group.groupKey} title={group.groupName} eventKey={group.groupKey}>
+            <ParticipantsTable data={group} />
+          </Tab>
+        ))}
+      </TabsContainer>
+    </ParticipantsContent>
+  )
+}
+
+export default Participants

--- a/frontend/src/components/professor/ParticipantsPage/ParticipantsStyles.js
+++ b/frontend/src/components/professor/ParticipantsPage/ParticipantsStyles.js
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+import { Content } from '../../App/AppGeneralStyles'
+import { Table, Tabs } from 'react-bootstrap'
+
+export const ParticipantsContent = styled(Content)`
+  padding: 15px;
+`
+
+export const TabsContainer = styled(Tabs)`
+  margin-bottom: 10px;
+
+  & .nav-link.active {
+    background-color: var(--button-green);
+    color: white;
+  }
+`
+
+export const TableContainer = styled(Table)`
+  color: var(--font-color);
+  margin-bottom: 0;
+
+  & tbody tr td {
+    vertical-align: middle;
+  }
+`

--- a/frontend/src/components/professor/ParticipantsPage/ParticipantsTable.js
+++ b/frontend/src/components/professor/ParticipantsPage/ParticipantsTable.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { GameCardOptionPick } from '../../student/GameCardPage/GameCardStyles'
+import { GameButton } from '../../student/GameCardPage/GameButton'
+import { TableContainer } from './ParticipantsStyles'
+
+function ParticipantsTable(props) {
+  const participants = props.data.participants
+
+  return (
+    <GameCardOptionPick>
+      <TableContainer>
+        <thead>
+          <tr>
+            <th>Nazwa grupy</th>
+            <th>Imię i nazwisko członka</th>
+            <th className={'text-center'}>Akcje</th>
+          </tr>
+        </thead>
+        <tbody>
+          {participants.length > 0 ? (
+            participants.map((participant, index) => (
+              <tr key={index + participant.groupName}>
+                <td className={'py-0'}>{participant.groupName}</td>
+                <td className={'py-0'}>{participant.name}</td>
+                <td className={'py-0'}>
+                  <GameButton text={'Zmień grupę'} customWidth={'auto'} />
+                </td>
+              </tr>
+            ))
+          ) : (
+            <p>Brak członków</p>
+          )}
+        </tbody>
+      </TableContainer>
+    </GameCardOptionPick>
+  )
+}
+
+export default ParticipantsTable

--- a/frontend/src/components/professor/ParticipantsPage/mockData.js
+++ b/frontend/src/components/professor/ParticipantsPage/mockData.js
@@ -1,0 +1,66 @@
+const groups = [
+  {
+    groupName: 'pon1440',
+    groupKey: 'pon1440',
+    participants: [
+      {
+        name: 'Jan Kowalski',
+        groupName: 'pon1440'
+      },
+      {
+        name: 'Jan Nowak',
+        groupName: 'pon1440'
+      },
+      {
+        name: 'Janusz Tracz',
+        groupName: 'pon1440'
+      },
+      {
+        name: 'Józef Nowacki',
+        groupName: 'pon1440'
+      },
+      {
+        name: 'Maciej Maciejowski',
+        groupName: 'pon1440'
+      }
+    ]
+  },
+  {
+    groupName: 'wt1250',
+    groupKey: 'wt1250',
+    participants: [
+      {
+        name: 'Iwan Groźny',
+        groupName: 'wt1250'
+      },
+      {
+        name: 'Marian Cis',
+        groupName: 'wt1250'
+      },
+      {
+        name: 'Mikołaj Nowak',
+        groupName: 'wt1250'
+      },
+      {
+        name: 'Patrycja Dudziak',
+        groupName: 'wt1250'
+      },
+      {
+        name: 'Filip Falafel',
+        groupName: 'wt1250'
+      }
+    ]
+  }
+]
+
+export const getGroups = () => {
+  return groups
+}
+
+export const getAllParticipants = () => {
+  return {
+    groupName: 'Wszyscy',
+    groupKey: 'all',
+    participants: groups.length === 0 ? [] : groups.map((group) => group.participants).flat(1)
+  }
+}

--- a/frontend/src/routes/modules/teacherRoutes/ActivityAssessmentRoutes.js
+++ b/frontend/src/routes/modules/teacherRoutes/ActivityAssessmentRoutes.js
@@ -3,8 +3,7 @@ import NotFound from '../../../components/general/NotFoundPage/NotFound'
 import PageGuard from '../../../components/general/PageGuard/PageGuard'
 import { Role } from '../../../utils/userRole'
 import ActivityAssessmentList from '../../../components/professor/ActivityAssessmentList/ActivityAssessmentList'
-import ActivityAssessmentDetails
-  from '../../../components/professor/ActivityAssessmentDetails/ActivityAssessmentDetails'
+import ActivityAssessmentDetails from '../../../components/professor/ActivityAssessmentDetails/ActivityAssessmentDetails'
 import { PageRoutes } from '../../PageRoutes'
 
 export default function ActivityAssessmentRoutes() {
@@ -13,7 +12,7 @@ export default function ActivityAssessmentRoutes() {
       <Route
         path={`${PageRoutes.Teacher.ActivityAssessment.ACTIVITY_ASSESSMENT_LIST}`}
         element={
-          <PageGuard role={Role.LOGGED_IS_AS_TEACHER}>
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
             <ActivityAssessmentList />
           </PageGuard>
         }
@@ -22,7 +21,7 @@ export default function ActivityAssessmentRoutes() {
       <Route
         path={`${PageRoutes.Teacher.ActivityAssessment.ACTIVITY_ASSESSMENT}`}
         element={
-          <PageGuard role={Role.LOGGED_IS_AS_TEACHER}>
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
             <ActivityAssessmentDetails />
           </PageGuard>
         }

--- a/frontend/src/routes/modules/teacherRoutes/GameManagementRoutes.js
+++ b/frontend/src/routes/modules/teacherRoutes/GameManagementRoutes.js
@@ -22,7 +22,7 @@ export default function GameManagementRoutes() {
       <Route
         path={`${PageRoutes.Teacher.GameManagement.Groups.GROUPS}`}
         element={
-          <PageGuard role={Role.LOGGED_IS_AS_TEACHER}>
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
             <Groups />
           </PageGuard>
         }
@@ -31,7 +31,7 @@ export default function GameManagementRoutes() {
       <Route
         path={`${PageRoutes.Teacher.GameManagement.Groups.GROUP_ADDITION}`}
         element={
-          <PageGuard role={Role.LOGGED_IS_AS_TEACHER}>
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
             <GroupAddition />
           </PageGuard>
         }

--- a/frontend/src/routes/modules/teacherRoutes/GameManagementRoutes.js
+++ b/frontend/src/routes/modules/teacherRoutes/GameManagementRoutes.js
@@ -13,7 +13,7 @@ export default function GameManagementRoutes() {
       <Route
         path={PageRoutes.Teacher.GameManagement.GAME_MANAGEMENT}
         element={
-          <PageGuard role={Role.LOGGED_IS_AS_TEACHER}>
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
             <GameManagement />
           </PageGuard>
         }

--- a/frontend/src/routes/modules/teacherRoutes/GameSummaryRoutes.js
+++ b/frontend/src/routes/modules/teacherRoutes/GameSummaryRoutes.js
@@ -11,7 +11,7 @@ export default function GameSummaryRoutes() {
       <Route
         path={`${PageRoutes.Teacher.GameSummary.GAME_SUMMARY}`}
         element={
-          <PageGuard role={Role.LOGGED_IS_AS_TEACHER}>
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
             <GameSummary />
           </PageGuard>
         }

--- a/frontend/src/routes/modules/teacherRoutes/ParticipantsRoutes.js
+++ b/frontend/src/routes/modules/teacherRoutes/ParticipantsRoutes.js
@@ -1,9 +1,21 @@
 import { Route, Routes } from 'react-router-dom'
 import NotFound from '../../../components/general/NotFoundPage/NotFound'
+import { PageRoutes } from '../../PageRoutes'
+import Participants from '../../../components/professor/ParticipantsPage/Participants'
+import { Role } from '../../../utils/userRole'
+import PageGuard from '../../../components/general/PageGuard/PageGuard'
 
 export default function ParticipantsRoutes() {
   return (
     <Routes>
+      <Route
+        path={PageRoutes.Teacher.Participants.PARTICIPANTS}
+        element={
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
+            <Participants />
+          </PageGuard>
+        }
+      />
       <Route path='*' element={<NotFound />} />
     </Routes>
   )

--- a/frontend/src/utils/userRole.js
+++ b/frontend/src/utils/userRole.js
@@ -1,7 +1,7 @@
 export const Role = {
   NOT_LOGGED_IN: 0,
   LOGGED_IN_AS_STUDENT: 1,
-  LOGGED_IS_AS_TEACHER: 2
+  LOGGED_IN_AS_TEACHER: 2
 }
 
 export const AccountType = {


### PR DESCRIPTION
Widok dostępny po kliknięciu w "uczestnicy" na sidebarze. Moim pomysłem na ten widok było wykorzystanie tabsów, które zmieniają wyświetlaną tabelę w zależności od wybranej grupy zajęciowej. Na razie wszystko na mockach. Dodatkowo napisałem funkcję, która być może się przyda (to zależy jak będą wyglądały dane zwracane przez backend) do zbierania studentów z każdej grupy w jedną.

Dodatkowo pozwoliłem sobie poprawić literówkę w `Role` z `LOGGED_IS_AS_TEACHER` na `LOGGED_IN_AS_TEACHER`