### PR TITLE
[SC-103] Added group code list endpoint (+ few tests)

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -26,11 +26,17 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.8'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
     implementation 'com.auth0:java-jwt:3.19.2'
+    implementation 'junit:junit:4.13.2'
+    implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.10'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.12.10'
+    testImplementation group: 'org.objenesis', name: 'objenesis', version: '3.2'
+
 }
 
 tasks.named('test') {

--- a/api/src/main/java/com/example/api/controller/group/GroupController.java
+++ b/api/src/main/java/com/example/api/controller/group/GroupController.java
@@ -21,7 +21,7 @@ public class GroupController {
         return ResponseEntity.ok().body(groupService.saveGroup(form));
     }
 
-    @GetMapping("/invitationCodeList")
+    @GetMapping("/invitation-code/list")
     ResponseEntity<List<GroupCode>> getInvitationCodeList() {
         return ResponseEntity.ok().body(groupService.getInvitationCodeList());
     }

--- a/api/src/main/java/com/example/api/controller/group/GroupController.java
+++ b/api/src/main/java/com/example/api/controller/group/GroupController.java
@@ -1,14 +1,14 @@
 package com.example.api.controller.group;
 
 import com.example.api.dto.request.group.SaveGroupForm;
+import com.example.api.dto.response.group.GroupCode;
 import com.example.api.model.group.Group;
 import com.example.api.service.group.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,5 +19,10 @@ public class GroupController {
     @PostMapping
     public ResponseEntity<Group> saveGroup(@RequestBody SaveGroupForm form) {
         return ResponseEntity.ok().body(groupService.saveGroup(form));
+    }
+
+    @GetMapping("/invitationCodeList")
+    ResponseEntity<List<GroupCode>> getInvitationCodeList() {
+        return ResponseEntity.ok().body(groupService.getInvitationCodeList());
     }
 }

--- a/api/src/main/java/com/example/api/dto/response/group/GroupCode.java
+++ b/api/src/main/java/com/example/api/dto/response/group/GroupCode.java
@@ -1,0 +1,22 @@
+package com.example.api.dto.response.group;
+
+import com.example.api.model.group.Group;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class GroupCode {
+    @Schema(required = true) private Long id;
+    @Schema(required = true) private String name;
+    @Schema(required = true) private String invitationCode;
+
+    public GroupCode(Group group) {
+        this.id = group.getId();
+        this.name = group.getName();
+        this.invitationCode = group.getInvitationCode();
+    }
+}

--- a/api/src/main/java/com/example/api/repo/group/GroupRepo.java
+++ b/api/src/main/java/com/example/api/repo/group/GroupRepo.java
@@ -6,5 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupRepo extends JpaRepository<Group, Long> {
+    Group findGroupById(Long id);
     Group findGroupByInvitationCode(String invitationCode);
 }

--- a/api/src/main/java/com/example/api/service/group/GroupService.java
+++ b/api/src/main/java/com/example/api/service/group/GroupService.java
@@ -1,6 +1,8 @@
 package com.example.api.service.group;
 
 import com.example.api.dto.request.group.SaveGroupForm;
+import com.example.api.dto.response.group.GroupCode;
+import com.example.api.error.exception.EntityNotFoundException;
 import com.example.api.model.group.AccessDate;
 import com.example.api.model.group.Group;
 import com.example.api.repo.group.AccessDateRepo;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class GroupService {
     private final AccessDateRepo accessDateRepo;
 
     public Group saveGroup(Group group) {
+        log.info("Saving group to database with name {}", group.getName());
         return groupRepo.save(group);
     }
 
@@ -34,5 +38,36 @@ public class GroupService {
         accessDateRepo.save(accessDate);
         Group group = new Group(null, form.getName(), new ArrayList<>(), accessDate, form.getInvitationCode());
         return groupRepo.save(group);
+    }
+
+    public Group getGroupById(Long id) throws EntityNotFoundException {
+        log.info("Fetching group with id {}", id);
+        Group group = groupRepo.findGroupById(id);
+        if (group == null) {
+            log.error("Group with id {} not found in database", id);
+            throw new EntityNotFoundException("Group with id" + id + " not found in database");
+        }
+        return group;
+    }
+
+    public Group getGroupByInvitationCode(String code) throws EntityNotFoundException {
+        log.info("Fetching group with code {}", code);
+        Group group = groupRepo.findGroupByInvitationCode(code);
+        if (group == null) {
+            log.error("Group with id {} not found in database", code);
+            throw new EntityNotFoundException("Group with code" + code + " not found in database");
+        }
+        return group;
+    }
+
+    public List<GroupCode> getInvitationCodeList() {
+        log.info("Fetching group code list");
+        return groupRepo.findAll()
+                .stream()
+                .map(group -> new GroupCode(group.getId(),
+                                            group.getName(),
+                                            group.getInvitationCode()))
+                .toList();
+
     }
 }

--- a/api/src/test/java/com/example/api/controller/group/GroupControllerTests.java
+++ b/api/src/test/java/com/example/api/controller/group/GroupControllerTests.java
@@ -1,0 +1,73 @@
+package com.example.api.controller.group;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.api.model.group.Group;
+import com.example.api.service.group.GroupService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GroupController.class)
+public class GroupControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GroupController groupController;
+
+    @MockBean
+    private GroupService service;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @MockBean
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    private ObjectWriter jsonWriter;
+    private Group group1;
+    private Group group2;
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+        jsonWriter = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        group1 = new Group();
+        group2 = new Group();
+        group1.setName("G1");
+        group2.setName("G2");
+        group1.setInvitationCode("Code1");
+        group2.setInvitationCode("Code 2");
+    }
+
+    @Test
+    public void saveGroupTest() throws Exception {
+        when(service.saveGroup((Group) any())).thenReturn(group1);
+
+        mockMvc.perform(
+                    post("/group")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonWriter.writeValueAsString(group1))
+                )
+                .andExpect(status().isOk())
+                // TODO: fix tests to return body
+                // .andExpect(content().string(containsString(group1.getName())))
+                // .andExpect(content().string(containsString(group1.getInvitationCode())))
+                .andReturn();
+    }
+}

--- a/api/src/test/java/com/example/api/service/group/GroupServiceTests.java
+++ b/api/src/test/java/com/example/api/service/group/GroupServiceTests.java
@@ -1,0 +1,97 @@
+package com.example.api.service.group;
+
+import com.example.api.dto.request.group.SaveGroupForm;
+import com.example.api.dto.response.group.GroupCode;
+import com.example.api.model.group.Group;
+import com.example.api.repo.group.AccessDateRepo;
+import com.example.api.repo.group.GroupRepo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.util.List;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
+public class GroupServiceTests {
+    @Mock private GroupRepo groupRepo;
+    @Mock private AccessDateRepo accessDateRepo;
+
+    private GroupService groupService;
+    private Group group1;
+    private Group group2;
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+        groupService = new GroupService(groupRepo, accessDateRepo);
+        group1 = new Group();
+        group2 = new Group();
+        group1.setName("G1");
+        group2.setName("G2");
+        group1.setInvitationCode("Code1");
+        group2.setInvitationCode("Code 2");
+    }
+
+    @Test
+    public void saveGroupByFormTest() {
+        // given
+        SaveGroupForm saveGroupForm = new SaveGroupForm();
+        saveGroupForm.setName(group1.getName());
+        saveGroupForm.setInvitationCode(group1.getInvitationCode());
+        when(groupRepo.save(any())).thenReturn(group1);
+
+        //when
+        Group result = groupService.saveGroup(saveGroupForm);
+
+        //then
+        Assertions.assertEquals(group1.getName(), result.getName());
+    }
+
+    @Test
+    public void saveGroupTest() {
+        // given
+        when(groupRepo.save(any())).thenReturn(group1);
+
+        //when
+        Group result = groupService.saveGroup(group1);
+
+        //then
+        Assertions.assertEquals(group1.getName(), result.getName());
+    }
+
+    @Test
+    public void getGroupCodeListTest() {
+        // given
+        when(groupRepo.findAll()).thenReturn(List.of(group1, group2));
+
+        // when
+        List<GroupCode> result = groupService.getInvitationCodeList();
+
+        // then
+        Assertions.assertEquals(result.size(), 2);
+        Assertions.assertEquals(result, List.of(new GroupCode(group1), new GroupCode(group2)));
+
+    }
+
+    @Test
+    public void getEmptyGroupCodeListTest() {
+        // given
+        when(groupRepo.findAll()).thenReturn(List.of());
+
+        // when
+        List<GroupCode> result = groupService.getInvitationCodeList();
+
+        // then
+        Assertions.assertEquals(result.size(), 0);
+        Assertions.assertEquals(result, List.of());
+
+    }
+}


### PR DESCRIPTION
Dodałem endpoint (/group/invitationCodeList) na liste wszystkich grup i ich kodów. Zwracana jest lista GroupCode (nowe DTO), które zawierają tylko informacje o id, nazwie grupy i kodzie. Dodałem jeszcze kilka testów dla serwisu i controllera. Te dla controllera nie są jeszcze skończone, bo nie wiem dlaczego body response'a jest zawsze puste, ale to najwyżej pózniej się naprawi przy uzupełnianiu testów.