### PR TITLE
[SC-126] Widok główny rozdziału u prowadzącego

### DIFF
--- a/frontend/src/components/general/LoginAndRegistrationPage/FormCol.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/FormCol.js
@@ -1,11 +1,44 @@
 import { ErrorMessage, Field } from 'formik'
 import { Col } from 'react-bootstrap'
 
-export const FormCol = (name, type, colName) => {
+export const FormCol = (name, type, colName, size = 12, additionalOptions) => {
   return (
-    <Col className='form-group' xs={12}>
+    <Col className='form-group' md={size}>
       <h6>{name}</h6>
-      <Field className='form-control' type={type} name={colName} />
+      {type === 'select' ? (
+        <Field className='form-control' name={colName} as={'select'} multiple={additionalOptions?.multiple ?? false}>
+          {additionalOptions?.options?.map((option, index) => (
+            <option key={option.value + index} value={option.value}>
+              {option.name}
+            </option>
+          ))}
+        </Field>
+      ) : type === 'checkbox' ? (
+        <div style={{ maxHeight: '100px', overflow: 'auto' }}>
+          {additionalOptions?.options?.map((option, index) => (
+            <div key={option.value + index} className={'w-100'}>
+              <label className={'d-flex align-items-center'}>
+                <Field
+                  className='form-control h-25 mx-2'
+                  style={{ width: 'inherit' }}
+                  type={type}
+                  name={colName}
+                  value={option.value}
+                />{' '}
+                <span>{option.name}</span>
+              </label>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <Field
+          className='form-control'
+          type={type}
+          name={colName}
+          min={type === 'number' ? additionalOptions?.min ?? 0 : 'none'}
+        />
+      )}
+
       <ErrorMessage name={colName} component='div'>
         {(msg) => <div style={{ color: 'var(--font-color)' }}>{msg}</div>}
       </ErrorMessage>

--- a/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
+++ b/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
@@ -1,0 +1,145 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { getChapterDetails } from '../GameManagement/mockData'
+import { Content } from '../../App/AppGeneralStyles'
+import { Button, Card, Col, Collapse, ListGroup, ListGroupItem, Row } from 'react-bootstrap'
+import { getActivityImg, getActivityTypeName } from '../../../utils/constants'
+import { ActivitiesCard, ButtonsCol, MapCard, SummaryCard } from './ChapterDetailsStyles'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowDown, faArrowUp } from '@fortawesome/free-solid-svg-icons'
+import { generateFullPath, PageRoutes } from '../../../routes/PageRoutes'
+import ActivityService from '../../../services/activity.service'
+import ChapterMap from '../../student/GameMapPage/Map/ChapterMap'
+import DeletionModal from './DeletionModal'
+import EditChapterModal from './EditChapterModal'
+
+function ChapterDetails() {
+  const { id: chapterId } = useParams()
+  const [openActivitiesDetailsList, setOpenActivitiesDetailsList] = useState(false)
+  const [openConditionsList, setOpenConditionsList] = useState(false)
+  const [chapterMap, setChapterMap] = useState()
+  const [isDeletionModalOpen, setDeletionModalOpen] = useState(false)
+  const [isEditChapterModalOpen, setEditChapterModalOpen] = useState(false)
+  const mapCardBody = useRef()
+
+  const chapterDetails = getChapterDetails(+chapterId)
+
+  useEffect(() => {
+    // todo: set mapId, now we always get first map
+    ActivityService.getActivityMap(1).then((response) => setChapterMap(response))
+  }, [])
+
+  return (
+    <Content>
+      <Row className={'px-0 m-0'} style={{ height: '100vh' }}>
+        <Col className={'m-0 h-100'} md={6}>
+          <Col md={12} className={'h-50'}>
+            <MapCard className={'mt-2'}>
+              <Card.Header>Mapa rozdziału</Card.Header>
+              <Card.Body ref={mapCardBody}>
+                {chapterMap && <ChapterMap map={chapterMap} marginNeeded parentRef={mapCardBody} />}
+              </Card.Body>
+            </MapCard>
+          </Col>
+          <Col md={12} style={{ height: '45%' }}>
+            <SummaryCard className={'h-100'}>
+              <Card.Header>Podsumowanie rozdziału</Card.Header>
+              <Card.Body className={'p-0'}>
+                <ListGroup>
+                  <ListGroupItem>Nazwa rozdziału: {chapterDetails.name}</ListGroupItem>
+                  <ListGroupItem>
+                    <Row className={'d-flex align-items-center'}>
+                      <Col sm={10}>Liczba dodanych aktywności: {chapterDetails.noActivities}</Col>
+                      <Col sm={2}>
+                        <FontAwesomeIcon
+                          icon={openActivitiesDetailsList ? faArrowUp : faArrowDown}
+                          className={'mx-5'}
+                          onClick={() => setOpenActivitiesDetailsList(!openActivitiesDetailsList)}
+                          aria-controls={'activities'}
+                          aria-expanded={openActivitiesDetailsList}
+                        />
+                      </Col>
+                    </Row>
+                    <Collapse in={openActivitiesDetailsList}>
+                      <div id='activities'>
+                        <div>Ekspedycje: {chapterDetails.noExpeditions}</div>
+                        <div>Zadania bojowe: {chapterDetails.noCombatTasks}</div>
+                        <div>Wytyczne: {chapterDetails.noInfoTasks}</div>
+                        <div>Wywiady: {chapterDetails.noSurveyTasks}</div>
+                      </div>
+                    </Collapse>
+                  </ListGroupItem>
+                  <ListGroupItem>Suma punktów możliwych do zdobycia w rozdziale: {chapterDetails.points}</ListGroupItem>
+                  <ListGroupItem>Punkty liczone jako 100%: {chapterDetails.points * 0.85}</ListGroupItem>
+                  <ListGroupItem>Aktualny rozmiar mapy: {chapterDetails.mapSize}</ListGroupItem>
+                  <ListGroupItem>
+                    <Row className={'d-flex align-items-center'}>
+                      <Col sm={10}>Warunki odblokowania kolejnego rozdziału:</Col>
+                      <Col sm={2}>
+                        <FontAwesomeIcon
+                          icon={openConditionsList ? faArrowUp : faArrowDown}
+                          className={'mx-5'}
+                          onClick={() => setOpenConditionsList(!openConditionsList)}
+                          aria-controls={'conditions'}
+                          aria-expanded={openConditionsList}
+                        />
+                      </Col>
+                    </Row>
+                    <Collapse in={openConditionsList}>
+                      <div id='conditions'>
+                        <ol>
+                          <li>uczestnik musi zdobyć 300 pkt</li>
+                          <li>data po 15.10.2022</li>
+                        </ol>
+                      </div>
+                    </Collapse>
+                  </ListGroupItem>
+                </ListGroup>
+              </Card.Body>
+            </SummaryCard>
+          </Col>
+        </Col>
+        <Col className={'m-0 h-100'} md={6}>
+          <Col md={12} style={{ height: '85vh' }}>
+            <ActivitiesCard style={{ height: '96.5%' }} className={'mt-2'}>
+              <Card.Header>Lista aktywności</Card.Header>
+              <Card.Body className={'p-0'}>
+                {chapterDetails.activities.map((activity, index) => (
+                  <ListGroup horizontal className={'w-100'} key={index + activity.title}>
+                    <ListGroupItem className={'p-0 d-flex align-items-center'}>
+                      <img src={getActivityImg(activity.type)} width={32} height={32} alt={'activity img'} />
+                    </ListGroupItem>
+                    <ListGroupItem className={'w-50'}>{getActivityTypeName(activity.type)}</ListGroupItem>
+                    <ListGroupItem className={'w-100'}>{activity.title}</ListGroupItem>
+                    <ListGroupItem className={'w-25'}>
+                      ({activity.posX}, {activity.posY})
+                    </ListGroupItem>
+                    <ListGroupItem className={'w-25'}>Pkt: {activity.points}</ListGroupItem>
+                  </ListGroup>
+                ))}
+              </Card.Body>
+            </ActivitiesCard>
+          </Col>
+          <ButtonsCol md={12} style={{ height: '10vh' }}>
+            <Link to={generateFullPath(() => PageRoutes.Teacher.GameManagement.GAME_MANAGEMENT)}>
+              <Button variant={'warning'}>Wyjdź</Button>
+            </Link>
+            <Button onClick={() => setEditChapterModalOpen(true)}>Edytuj rozdział</Button>
+            <Button variant={'danger'} onClick={() => setDeletionModalOpen(true)}>
+              Usuń rozdział
+            </Button>
+          </ButtonsCol>
+        </Col>
+      </Row>
+
+      <DeletionModal
+        showModal={isDeletionModalOpen}
+        setModalOpen={setDeletionModalOpen}
+        chapterTitle={chapterDetails.name}
+      />
+      <EditChapterModal showModal={isEditChapterModalOpen} setModalOpen={setEditChapterModalOpen} />
+    </Content>
+  )
+}
+
+export default ChapterDetails

--- a/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
+++ b/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { getChapterDetails } from '../GameManagement/mockData'
 import { Content } from '../../App/AppGeneralStyles'
-import { Button, Card, Col, Collapse, ListGroup, ListGroupItem, Row } from 'react-bootstrap'
+import { Button, Card, Col, Collapse, ListGroup, ListGroupItem, Row, Table } from 'react-bootstrap'
 import { getActivityImg, getActivityTypeName } from '../../../utils/constants'
 import { ActivitiesCard, ButtonsCol, MapCard, SummaryCard } from './ChapterDetailsStyles'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -104,19 +104,23 @@ function ChapterDetails() {
             <ActivitiesCard style={{ height: '96.5%' }} className={'mt-2'}>
               <Card.Header>Lista aktywności</Card.Header>
               <Card.Body className={'p-0'}>
-                {chapterDetails.activities.map((activity, index) => (
-                  <ListGroup horizontal className={'w-100'} key={index + activity.title}>
-                    <ListGroupItem className={'p-0 d-flex align-items-center'}>
-                      <img src={getActivityImg(activity.type)} width={32} height={32} alt={'activity img'} />
-                    </ListGroupItem>
-                    <ListGroupItem className={'w-50'}>{getActivityTypeName(activity.type)}</ListGroupItem>
-                    <ListGroupItem className={'w-100'}>{activity.title}</ListGroupItem>
-                    <ListGroupItem className={'w-25'}>
-                      ({activity.posX}, {activity.posY})
-                    </ListGroupItem>
-                    <ListGroupItem className={'w-25'}>Pkt: {activity.points}</ListGroupItem>
-                  </ListGroup>
-                ))}
+                <Table>
+                  <tbody>
+                    {chapterDetails.activities.map((activity, index) => (
+                      <tr key={activity.title + index}>
+                        <td>
+                          <img src={getActivityImg(activity.type)} width={32} height={32} alt={'activity img'} />
+                        </td>
+                        <td>{getActivityTypeName(activity.type)}</td>
+                        <td>{activity.title}</td>
+                        <td>
+                          ({activity.posX}, {activity.posY})
+                        </td>
+                        <td>Pkt: {activity.points}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
               </Card.Body>
             </ActivitiesCard>
           </Col>

--- a/frontend/src/components/professor/ChapterDetails/ChapterDetailsStyles.js
+++ b/frontend/src/components/professor/ChapterDetails/ChapterDetailsStyles.js
@@ -1,0 +1,69 @@
+import styled from 'styled-components'
+import { Card, Col } from 'react-bootstrap'
+
+const ChapterCard = styled(Card)`
+  color: var(--font-color);
+
+  .card-header {
+    font-weight: bold;
+    letter-spacing: 1px;
+    background-color: var(--dark-blue);
+  }
+
+  .card-body {
+    background-color: #223762;
+  }
+`
+
+export const MapCard = styled(ChapterCard)`
+  .card-body {
+    padding: 0;
+    max-height: 43vh !important;
+    height: 43vh !important;
+  }
+`
+export const SummaryCard = styled(ChapterCard)`
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  .list-group-item {
+    background-color: #223762;
+  }
+
+  #activities,
+  #conditions {
+    border-top: 1px solid gray;
+    margin-top: 5px;
+    padding-top: 5px;
+    color: gray;
+  }
+`
+export const ActivitiesCard = styled(ChapterCard)`
+  max-height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  .list-group-item {
+    background-color: #223762;
+    display: flex;
+    align-items: center;
+  }
+  .list-group:hover {
+    background-color: var(--dark-blue);
+    cursor: pointer;
+
+    & .list-group-item {
+      background-color: transparent;
+    }
+  }
+`
+export const ButtonsCol = styled(Col)`
+  height: 10vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  column-gap: 10px;
+
+  position: relative;
+  bottom: 1.5rem;
+`

--- a/frontend/src/components/professor/ChapterDetails/ChapterDetailsStyles.js
+++ b/frontend/src/components/professor/ChapterDetails/ChapterDetailsStyles.js
@@ -43,17 +43,11 @@ export const ActivitiesCard = styled(ChapterCard)`
   overflow-y: auto;
   overflow-x: hidden;
 
-  .list-group-item {
-    background-color: #223762;
-    display: flex;
-    align-items: center;
-  }
-  .list-group:hover {
-    background-color: var(--dark-blue);
-    cursor: pointer;
+  .table {
+    color: var(--font-color);
 
-    & .list-group-item {
-      background-color: transparent;
+    & td {
+      border: 1px solid rgba(0, 0, 0, 0.125);
     }
   }
 `

--- a/frontend/src/components/professor/ChapterDetails/DeletionModal.js
+++ b/frontend/src/components/professor/ChapterDetails/DeletionModal.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Button, Card, Modal } from 'react-bootstrap'
+
+function DeletionModal(props) {
+  return (
+    <Modal show={props.showModal}>
+      <Card>
+        <Card.Header>
+          <Card.Title>Usunięcie rozdziału</Card.Title>
+        </Card.Header>
+        <Card.Body>
+          Czy na pewno chcesz usunąć rozdział: <br />
+          <strong>{props.chapterTitle}</strong>?
+        </Card.Body>
+        <Card.Footer className={'text-center'}>
+          <Button className={'mr-1'} variant={'secondary'} onClick={() => props.setModalOpen(false)}>
+            Anuluj
+          </Button>
+          <Button variant={'danger'}>Usuń</Button>
+        </Card.Footer>
+      </Card>
+    </Modal>
+  )
+}
+
+export default DeletionModal

--- a/frontend/src/components/professor/ChapterDetails/EditChapterModal.js
+++ b/frontend/src/components/professor/ChapterDetails/EditChapterModal.js
@@ -1,0 +1,99 @@
+import React, { useState } from 'react'
+import { Button, Card, Col, Container, Form, Modal, ModalBody, ModalFooter, Row, Spinner } from 'react-bootstrap'
+import { FIELD_REQUIRED, POSITIVE_NUMBER } from '../../../utils/constants'
+import { FormCol } from '../../general/LoginAndRegistrationPage/FormCol'
+import { Formik } from 'formik'
+
+function EditChapterModal(props) {
+  const [isSuccessModalOpen, setSuccessModalOpen] = useState(false)
+
+  return (
+    <>
+      <Modal show={props.showModal} size={'lg'} centered>
+        <Card>
+          <Card.Header>
+            <Card.Title>Edycja rozdziału</Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <Formik
+              initialValues={{
+                chapterName: '',
+                chapterSizeX: '',
+                chapterSizeY: '',
+                points100: '',
+                chapterConditions: []
+              }}
+              validate={(values) => {
+                const errors = {}
+                if (!values.chapterName) errors.chapterName = FIELD_REQUIRED
+                if (!values.chapterSizeX) errors.chapterSizeX = POSITIVE_NUMBER
+                if (!values.chapterSizeY) errors.chapterSizeY = POSITIVE_NUMBER
+                if (!values.points100) errors.points100 = POSITIVE_NUMBER
+                if (values.chapterConditions.length === 0) errors.chapterConditions = FIELD_REQUIRED
+                return errors
+              }}
+              onSubmit={(values, { setSubmitting }) => {
+                // TODO: send edit data to backend
+                props.setModalOpen(false)
+                setSuccessModalOpen(true)
+                setSubmitting(false)
+              }}
+            >
+              {({ isSubmitting, values, errors, handleSubmit }) => (
+                <Form onSubmit={handleSubmit}>
+                  <Container>
+                    <Row className='mx-auto'>
+                      {FormCol('Nazwa rozdziału', 'text', 'chapterName', 6)}
+                      {FormCol('Liczba kolumn', 'number', 'chapterSizeX', 3, { min: 1 })}
+                      {FormCol('Liczba wierszy', 'number', 'chapterSizeY', 3, { min: 1 })}
+                      {FormCol('Punkty liczone jako 100%', 'number', 'points100', 4, { min: 1 })}
+                      {FormCol('Warunki odblokowania kolejnego rozdziału', 'checkbox', 'chapterConditions', 8, {
+                        options: [
+                          { value: 'option1', name: 'Uczestnik musi zdobyć 50% punktów z liczonych jako 100%' },
+                          { value: 'option2', name: 'Gdy minie data otwarcia kolejnego rozdziału' },
+                          { value: 'option3', name: 'Option 1' },
+                          { value: 'option4', name: 'Option 2' }
+                        ]
+                      })}
+                    </Row>
+                    <Row className='mt-4 d-flex justify-content-center'>
+                      <Col sm={12} className='d-flex justify-content-center mb-2'>
+                        <Button variant={'danger'} className={'mr-2'} onClick={() => props.setModalOpen(false)}>
+                          Anuluj
+                        </Button>
+                        <Button
+                          type='submit'
+                          disabled={isSubmitting}
+                          style={{
+                            backgroundColor: 'var(--button-green)',
+                            borderColor: 'var(--button-green)'
+                          }}
+                        >
+                          {isSubmitting ? (
+                            <Spinner as='span' animation='border' size='sm' role='status' />
+                          ) : (
+                            <span>Zapisz zmiany</span>
+                          )}
+                        </Button>
+                      </Col>
+                    </Row>
+                  </Container>
+                </Form>
+              )}
+            </Formik>
+          </Card.Body>
+        </Card>
+      </Modal>
+      <Modal show={isSuccessModalOpen}>
+        <ModalBody className={'text-center'}>Dane rozdziału zmienione pomyślnie.</ModalBody>
+        <ModalFooter className={'justify-content-center'}>
+          <Button variant={'success'} onClick={() => setSuccessModalOpen(false)}>
+            Zakończ
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  )
+}
+
+export default EditChapterModal

--- a/frontend/src/components/professor/GameManagement/GameManagement.js
+++ b/frontend/src/components/professor/GameManagement/GameManagement.js
@@ -5,10 +5,20 @@ import { GameCardOptionPick } from '../../student/GameCardPage/GameCardStyles'
 import { GameButton } from '../../student/GameCardPage/GameButton'
 import { generateFullPath, PageRoutes } from '../../../routes/PageRoutes'
 import ManagementCard from './ManagementCard'
+import { useNavigate } from 'react-router-dom'
+import { TableBodyRow } from './TableStyles'
 
 export default function GameManagement() {
   // TODO: use endpoint later
   const chaptersList = getChaptersList()
+
+  const navigate = useNavigate()
+
+  const goToChapterDetailsView = (chapterName, chapterId) => {
+    navigate(
+      generateFullPath(() => PageRoutes.Teacher.GameManagement.Chapters.CHAPTER) + `/${chapterName}/${chapterId}`
+    )
+  }
 
   return (
     <Content>
@@ -33,12 +43,12 @@ export default function GameManagement() {
                 </thead>
                 <tbody>
                   {chaptersList.map((chapter, index) => (
-                    <tr key={index}>
+                    <TableBodyRow key={index} onClick={() => goToChapterDetailsView(chapter.name, chapter.id)}>
                       <td>{chapter.name}</td>
                       <td className='text-center'>{chapter.noActivities}</td>
                       <td className='text-center'>{chapter.points}</td>
                       <td className='text-center'>{chapter.mapSize}</td>
-                    </tr>
+                    </TableBodyRow>
                   ))}
                 </tbody>
               </Table>

--- a/frontend/src/components/professor/GameManagement/TableStyles.js
+++ b/frontend/src/components/professor/GameManagement/TableStyles.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const TableBodyRow = styled.tr`
+  &:hover {
+    cursor: pointer;
+    background-color: #223762;
+  }
+`

--- a/frontend/src/components/professor/GameManagement/mockData.js
+++ b/frontend/src/components/professor/GameManagement/mockData.js
@@ -1,18 +1,100 @@
 const chaptersList = [
   {
+    id: 1,
     name: 'Rozdział 1: Witaj w dżungli!',
-    noActivities: 7,
+    noActivities: 6,
+    noExpeditions: 2,
+    noSurveyTasks: 1,
+    noInfoTasks: 1,
+    noCombatTasks: 2,
     points: 500,
-    mapSize: '11 x 7'
+    mapSize: '11 x 7',
+    activities: [
+      {
+        id: 1,
+        posX: 5,
+        posY: 4,
+        type: 'EXPEDITION',
+        title: 'Dżungla kabli 1',
+        points: 10
+      },
+      {
+        id: 2,
+        posX: 2,
+        posY: 2,
+        type: 'EXPEDITION',
+        title: 'Dżungla kabli 2',
+        points: 30
+      },
+      {
+        id: 1,
+        posX: 3,
+        posY: 3,
+        type: 'TASK',
+        title: 'Skakanka',
+        points: 55
+      },
+      {
+        id: 1,
+        posX: 3,
+        posY: 0,
+        type: 'INFO',
+        title: 'Wszystko co musisz wiedzieć o kablach.',
+        points: 0
+      }
+    ]
   },
   {
+    id: 2,
     name: 'Rozdział 2: Kable! Wszędzie kable!',
     noActivities: 4,
+    noExpeditions: 2,
+    noSurveyTasks: 1,
+    noInfoTasks: 1,
+    noCombatTasks: 2,
     points: 750,
-    mapSize: '8 x 6'
+    mapSize: '8 x 6',
+    activities: [
+      {
+        id: 1,
+        posX: 5,
+        posY: 4,
+        type: 'EXPEDITION',
+        title: 'Dżungla kabli 1',
+        points: 10
+      },
+      {
+        id: 2,
+        posX: 2,
+        posY: 2,
+        type: 'EXPEDITION',
+        title: 'Dżungla kabli 2',
+        points: 30
+      },
+      {
+        id: 1,
+        posX: 3,
+        posY: 3,
+        type: 'TASK',
+        title: 'Skakanka',
+        points: 55
+      },
+      {
+        id: 1,
+        posX: 3,
+        posY: 0,
+        type: 'INFO',
+        title: 'Wszystko co musisz wiedzieć o kablach.',
+        points: 0
+      }
+    ]
   }
 ]
 
 export const getChaptersList = () => {
   return chaptersList
+}
+
+export const getChapterDetails = (chapterId) => {
+  return chaptersList.find(({ id }) => id === chapterId)
 }

--- a/frontend/src/components/student/GameMapPage/ChaptersList/ChaptersNav.js
+++ b/frontend/src/components/student/GameMapPage/ChaptersList/ChaptersNav.js
@@ -1,46 +1,39 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Tab } from 'react-bootstrap'
 import ChapterMap from '../Map/ChapterMap'
 import { TabColored } from './ChaptersNavStyle'
 import Loader from '../../../general/Loader/Loader'
 import ActivityService from '../../../../services/activity.service'
+import { uniqBy } from 'lodash'
 
 function ChaptersNav() {
-  const [chapterMap, setChapterMap] = useState()
-  const [tabs, setTabs] = useState([])
+  const [chaptersMap, setChaptersMap] = useState([])
+  const chapterMapParentRef = useRef()
 
+  // TODO: z jakiegos powodu wywolywany jest ten endpoint za kazdym razem gdy sie strona odswiezy
+  //  i dlatego zawsze duplikowalo mapy i sie pojawialy nowe pod spodem przy auto-refreshu
+  //  na razie dodalem uniqBy ale trzeba zbadać sprawe
   useEffect(() => {
     // todo: set mapId, now we always get first map
-    ActivityService.getActivityMap(1).then((response) => setChapterMap(response))
+    ActivityService.getActivityMap(1).then((response) => {
+      return setChaptersMap(uniqBy([...chaptersMap, response], 'id'))
+    })
+    // eslint-disable-next-line
   }, [])
-
-  useEffect(() => {
-    if (chapterMap) {
-      setTabs((tabs) => {
-        return [
-          ...tabs,
-          React.cloneElement(
-            <Tab key={'Example map'} eventKey={'Example map'} title={'Example map'}>
-              <ChapterMap map={chapterMap} />
-            </Tab>
-          )
-        ]
-      })
-    }
-  }, [chapterMap])
 
   return (
     <>
-      {tabs.length === 0 ? (
+      {chaptersMap.length === 0 ? (
         <Loader />
       ) : (
-        <TabColored
-          defaultActiveKey={'Example map'}
-          id='chaptersNav'
-          className='mb-3 justify-content-center'
-          unmountOnExit={true}
-        >
-          {tabs}
+        <TabColored defaultActiveKey={'Example map'} id='chaptersNav' className='mb-3 justify-content-center'>
+          {chaptersMap.map((chapter, index) => (
+            <Tab key={index + Date.now()} eventKey={'Example map'} title={'Example map'}>
+              <div style={{ maxHeight: '70vh', height: '70vh', width: '100%' }} ref={chapterMapParentRef}>
+                <ChapterMap map={chapter} marginNeeded mapClickable parentRef={chapterMapParentRef} />
+              </div>
+            </Tab>
+          ))}
         </TabColored>
       )}
     </>

--- a/frontend/src/components/student/GameMapPage/GameMapStyles.js
+++ b/frontend/src/components/student/GameMapPage/GameMapStyles.js
@@ -6,11 +6,13 @@ import background from './resources/background.png'
 export const GameContent = styled(Content)`
   background: url('${background}') no-repeat;
   background-size: cover;
+  max-height: 100vh;
 `
 
 export const Map = styled(Container)`
   display: flex;
   flex-direction: column;
+  justify-content: center;
 
   @media (max-width: 1000px) {
     width: 100%;

--- a/frontend/src/components/student/GameMapPage/Map/ActivityField.js
+++ b/frontend/src/components/student/GameMapPage/Map/ActivityField.js
@@ -1,32 +1,18 @@
-import React, { useLayoutEffect, useRef } from 'react'
+import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getActivityByPosition } from '../../../../storage/activityMap'
 import { getActivityImg, getActivityPath } from '../../../../utils/constants'
 import { ActivityCol } from './ActivityFieldStyle'
 
-export default function ActivityField({ activity, posX, posY, mapSizeX, mapSizeY }) {
-  const activityCol = useRef(null)
+export default function ActivityField({ activity, posX, posY, colClickable, colSize }) {
   const navigate = useNavigate()
-
-  useLayoutEffect(() => {
-    function setHeight() {
-      if (activityCol.current) {
-        const resizeScale = 0.7
-        const possibleSize =
-          (Math.min(window.innerHeight, window.innerWidth) * resizeScale) / Math.max(mapSizeY, mapSizeX)
-        activityCol.current.setAttribute('style', `height:${possibleSize}px; width: ${possibleSize}px`)
-      }
-    }
-
-    setHeight() // first time, on component mount
-    window.addEventListener('resize', setHeight) // always when window resize
-  })
 
   // TODO, currently goes to the hard-coded expedition activity but it should be OK once we implement a 'real' activity getter in API
   const startActivity = () => {
-    navigate(`${getActivityPath(activity.type)}`, {
-      state: { activityId: activity.id }
-    })
+    colClickable &&
+      navigate(`${getActivityPath(activity.type)}`, {
+        state: { activityId: activity.id }
+      })
   }
 
   const isCompletedActivityAround = () => {
@@ -43,7 +29,7 @@ export default function ActivityField({ activity, posX, posY, mapSizeX, mapSizeY
   }
 
   return (
-    <ActivityCol ref={activityCol}>
+    <ActivityCol $isClickable={colClickable} $colSize={colSize}>
       {activity ? (
         <img src={getActivityImg(activity.type)} alt='activityImg' onClick={startActivity} />
       ) : (

--- a/frontend/src/components/student/GameMapPage/Map/ActivityFieldStyle.js
+++ b/frontend/src/components/student/GameMapPage/Map/ActivityFieldStyle.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Col } from 'react-bootstrap'
 
 export const ActivityCol = styled(Col)`
@@ -8,6 +8,8 @@ export const ActivityCol = styled(Col)`
   padding: 0;
   flex-basis: auto;
   flex-grow: 0;
+  width: ${(props) => props.$colSize + 'px'};
+  height: ${(props) => props.$colSize + 'px'};
 
   & img,
   & div {
@@ -16,8 +18,12 @@ export const ActivityCol = styled(Col)`
     border-radius: 5px;
   }
 
-  &:hover {
-    cursor: pointer;
-    transform: scale(1.1);
-  }
+  ${(props) =>
+    props.$isClickable &&
+    css`
+      &:hover {
+        cursor: pointer;
+        transform: scale(1.1);
+      }
+    `}
 `

--- a/frontend/src/components/student/GameMapPage/Map/ChapterMap.js
+++ b/frontend/src/components/student/GameMapPage/Map/ChapterMap.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { Row } from 'react-bootstrap'
 import Loader from '../../../general/Loader/Loader'
 import { Map } from '../GameMapStyles'
@@ -20,8 +20,34 @@ function createMap(map) {
   return rowsObj
 }
 
-export default function ChapterMap({ map }) {
+export default function ChapterMap({ map, marginNeeded, parentRef, mapClickable }) {
+  const [size, setSize] = useState(undefined)
+
   const rows = createMap(map)
+
+  const getParentSize = useCallback(() => {
+    const emptySpaceX = 32 + rows[0].length * 2
+    const emptySpaceY = 32 + rows.length * 2 + marginNeeded ? 32 : 0 // margin-x only
+    console.log(parentRef?.current?.offsetWidth, parentRef.current?.offsetHeight)
+    if (parentRef?.current?.offsetWidth && parentRef.current?.offsetHeight) {
+      return {
+        x: parentRef?.current?.offsetWidth - emptySpaceX,
+        y: parentRef.current?.offsetHeight - emptySpaceY
+      }
+    } else return { x: 0, y: 0 }
+  }, [marginNeeded, parentRef, rows])
+
+  useEffect(() => {
+    function setHeight() {
+      let { x, y } = getParentSize()
+      console.log(x, y)
+      const possibleSize = Math.floor(Math.min(x / map.mapSizeX, y / map.mapSizeY))
+      setSize(possibleSize ?? 0)
+    }
+
+    setHeight() // first time, on component mount
+    window.addEventListener('resize', setHeight) // always when window resize
+  }, [parentRef, map.mapSizeX, map.mapSizeY, getParentSize])
 
   const MapRows = rows.map((row, idx1) => (
     <Row key={idx1} className='mx-auto'>
@@ -31,8 +57,8 @@ export default function ChapterMap({ map }) {
           activity={activity}
           posX={idx2}
           posY={idx1}
-          mapSizeY={map.mapSizeY}
-          mapSizeX={map.mapSizeX}
+          colClickable={mapClickable}
+          colSize={size}
         />
       ))}
     </Row>
@@ -43,7 +69,7 @@ export default function ChapterMap({ map }) {
       {!rows ? (
         <Loader />
       ) : (
-        <Map fluid className='h-100 my-5'>
+        <Map fluid className={`${marginNeeded && 'my-2'} h-100`}>
           {MapRows}
         </Map>
       )}

--- a/frontend/src/components/student/GameMapPage/Map/ChapterMap.js
+++ b/frontend/src/components/student/GameMapPage/Map/ChapterMap.js
@@ -28,7 +28,7 @@ export default function ChapterMap({ map, marginNeeded, parentRef, mapClickable 
   const getParentSize = useCallback(() => {
     const emptySpaceX = 32 + rows[0].length * 2
     const emptySpaceY = 32 + rows.length * 2 + marginNeeded ? 32 : 0 // margin-x only
-    console.log(parentRef?.current?.offsetWidth, parentRef.current?.offsetHeight)
+
     if (parentRef?.current?.offsetWidth && parentRef.current?.offsetHeight) {
       return {
         x: parentRef?.current?.offsetWidth - emptySpaceX,
@@ -40,7 +40,6 @@ export default function ChapterMap({ map, marginNeeded, parentRef, mapClickable 
   useEffect(() => {
     function setHeight() {
       let { x, y } = getParentSize()
-      console.log(x, y)
       const possibleSize = Math.floor(Math.min(x / map.mapSizeX, y / map.mapSizeY))
       setSize(possibleSize ?? 0)
     }

--- a/frontend/src/routes/PageRoutes.js
+++ b/frontend/src/routes/PageRoutes.js
@@ -62,9 +62,12 @@ export const PageRoutes = {
       MAIN_PATH: 'game-management/*',
       GAME_MANAGEMENT: '',
       Groups: {
-        MAIN_PATH: '*',
-        GROUPS: 'groups',
-        GROUP_ADDITION: 'groups/group-addition'
+        MAIN_PATH: '',
+        GROUPS: 'groups'
+      },
+      Chapters: {
+        MAIN_PATH: '',
+        CHAPTER: 'chapter'
       }
     },
     Participants: {

--- a/frontend/src/routes/modules/teacherRoutes/GameManagementRoutes.js
+++ b/frontend/src/routes/modules/teacherRoutes/GameManagementRoutes.js
@@ -5,6 +5,7 @@ import { Role } from '../../../utils/userRole'
 import Groups from '../../../components/professor/GroupsPage/Groups'
 import { PageRoutes } from '../../PageRoutes'
 import GameManagement from '../../../components/professor/GameManagement/GameManagement'
+import ChapterDetails from '../../../components/professor/ChapterDetails/ChapterDetails'
 
 export default function GameManagementRoutes() {
   return (
@@ -19,10 +20,19 @@ export default function GameManagementRoutes() {
       />
 
       <Route
-        path={`${PageRoutes.Teacher.GameManagement.Groups.GROUPS}`}
+        path={PageRoutes.Teacher.GameManagement.Groups.GROUPS}
         element={
           <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
             <Groups />
+          </PageGuard>
+        }
+      />
+
+      <Route
+        path={PageRoutes.Teacher.GameManagement.Chapters.CHAPTER + '/:name/:id'}
+        element={
+          <PageGuard role={Role.LOGGED_IN_AS_TEACHER}>
+            <ChapterDetails />
           </PageGuard>
         }
       />

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -62,6 +62,7 @@ export const TeacherSidebarTitles = {
 }
 
 export const FIELD_REQUIRED = 'Pole wymagane.'
+export const POSITIVE_NUMBER = 'Wymagana liczba dodatnia.'
 export const START_GRAPH_NODE_ID = -1
 
 export const Activity = {


### PR DESCRIPTION
W tym tasku zrobiłem widok zarządzania rozdziałem dostępny z panelu zarządzania grą po kliknięciu w wybrany wiersz tabeli rozdziałów.
Umieściłem w nim też podgląd mapy wybranego rozdziału. Zrodziło to wiele problemów, dlatego że musiałem zmodyfikować komponent odpowiedzialny za wyświetlanie mapy w taki sposób, żeby mapa dopasowywała się do rozmiaru rodzica, a nie do rozmiaru całego okna przeglądarki. Żeby to było możliwe przeniosłem kod generujący wymiary kafelka z komponentu kafelka do komponentu mapy i napisałem od zera generator wymiaru kafelka. Dodałem też możliwość wyłączenia klikalności kafelków na mapie. Przy okazji znalazłem buga powodującego rerender mapy przy auto-refreshu (mapa duplikowała się pod oryginalną mapą) opisałem to komentarzem TODO.
Dodałem trzy buttony, w tym jeden umożliwiający edycję rozdziału (na razie oczywiście nic nie robi) otwierający modala z formularzem edycji. W formularzu skorzystałem z istniejącego już FormCol, ale był mocno ograniczony więc go zmodyfikowałem żeby działał dla większej liczby przypadków.
Ogólnie zmieniło się bardzo dużo bardzo ważnego kodu, dlatego proszę o bardzo dokładne review i sprawdzenie czy na pewno mapy wyświetlają się poprawnie u studenta i u prowadzącego, i czy w konsoli przeglądarki nie ma errorów ("u mnie działa" ale to dopiero połowa sukcesu ;) )