### PR TITLE
[SC-141] Refactor sposobu logowania

### DIFF
--- a/frontend/src/actions/auth.js
+++ b/frontend/src/actions/auth.js
@@ -1,4 +1,3 @@
-import { Navigate } from 'react-router-dom'
 import AuthService from '../services/auth.service'
 import { LOGIN_FAIL, LOGIN_SUCCESS, LOGOUT, REGISTER_FAIL, REGISTER_SUCCESS, SET_MESSAGE } from './types'
 import { generateFullPath, PageRoutes } from '../routes/PageRoutes'
@@ -48,8 +47,8 @@ export const login = (email, password) => (dispatch) => {
     })
 }
 
-export const logout = () => (dispatch) => {
+export const logout = (navigate) => (dispatch) => {
   AuthService.logout()
   dispatch({ type: LOGOUT })
-  Navigate(generateFullPath(() => PageRoutes.General.HOME))
+  navigate(generateFullPath(() => PageRoutes.General.HOME))
 }

--- a/frontend/src/common/auth-verify.js
+++ b/frontend/src/common/auth-verify.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import authService from '../services/auth.service'
 import { parseJwt } from '../utils/Api'
 import { connect } from 'react-redux'
 import { logout } from '../actions/auth'
+import { refreshSessionToast } from '../utils/toasts'
 
 function AuthVerify(props) {
   const navigate = useNavigate()
@@ -14,8 +14,11 @@ function AuthVerify(props) {
       props.dispatch(logout(navigate))
     } else if (props.user) {
       const decodedJwt = parseJwt(props.user.access_token)
+
       if (decodedJwt.exp * 1000 < Date.now()) {
-        authService.refreshToken(props.user.refresh_token).catch(() => props.dispatch(logout(navigate)))
+        props.dispatch(logout(navigate))
+      } else if (decodedJwt.exp * 1000 < Date.now() + 15 * 60 * 1000) {
+        refreshSessionToast(props.user, props.dispatch, navigate)
       }
     }
   }, [navigate, props, pathname])

--- a/frontend/src/components/general/Sidebar/MobileNavbar.js
+++ b/frontend/src/components/general/Sidebar/MobileNavbar.js
@@ -1,18 +1,20 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import { Nav } from 'react-bootstrap'
 import { connect } from 'react-redux'
-import { Link } from 'react-router-dom'
 import { logout } from '../../../actions/auth'
 import { buildNavLinkMobile, NavLinkStylesMobile } from './navBuilder'
 import { MobileNav } from './SidebarStyles'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons'
 import { generateFullPath, PageRoutes } from '../../../routes/PageRoutes'
 
 function MobileNavbar(props) {
+  const navigate = useNavigate()
+
   // todo: for teacher bar is too many icons, fix it
   const link_titles = props.link_titles
-  const logOut = () => props.dispatch(logout())
+  const logOut = () => props.dispatch(logout(navigate))
 
   return (
     <MobileNav>

--- a/frontend/src/components/general/Sidebar/Sidebar.js
+++ b/frontend/src/components/general/Sidebar/Sidebar.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import { faFire } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Nav } from 'react-bootstrap'
@@ -6,12 +7,12 @@ import { buildNavLink, NavLinkStyles } from './navBuilder'
 import { LogoDiv, NavBarTextContainer, NavEdit, SidebarEdit } from './SidebarStyles'
 import { connect } from 'react-redux'
 import { logout } from '../../../actions/auth'
-import { Link } from 'react-router-dom'
 import { generateFullPath, PageRoutes } from '../../../routes/PageRoutes'
 
 function Sidebar(props) {
+  const navigate = useNavigate()
   const link_titles = props.link_titles
-  const logOut = () => props.dispatch(logout())
+  const logOut = () => props.dispatch(logout(navigate))
 
   return (
     <SidebarEdit variant='dark'>

--- a/frontend/src/services/auth.service.js
+++ b/frontend/src/services/auth.service.js
@@ -57,7 +57,7 @@ class AuthService {
         localStorage.setItem('user', JSON.stringify(response.data))
       })
       .catch((err) => {
-        this.logout()
+        throw err
       })
   }
 }

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import authHeader from '../services/auth-header'
-import { errorToast } from './errorToast'
+import { toasts } from './toasts'
 
 const header = Object.assign(authHeader(), { 'Content-Type': 'application/x-www-form-urlencoded' })
 const headerWithParams = (params) => Object.assign(header, { params })
@@ -12,7 +12,7 @@ export function axiosApiPost(url, body) {
     .post(url, body, header)
     .then((response) => response.data)
     .catch((error) => {
-      errorToast(error?.response?.data?.message)
+      toasts(error?.response?.data?.message)
       throw error
     })
 }
@@ -22,7 +22,7 @@ export function axiosApiGet(url, params) {
     .get(url, headerWithParams(params))
     .then((response) => response.data)
     .catch((error) => {
-      errorToast(error?.response?.data?.message)
+      toasts(error?.response?.data?.message)
       throw error
     })
 }
@@ -32,7 +32,7 @@ export function axiosApiDelete(url, params) {
     .delete(url, headerWithParams(params))
     .then((response) => response.data)
     .catch((error) => {
-      errorToast(error?.response?.data?.message)
+      toasts(error?.response?.data?.message)
       throw error
     })
 }
@@ -54,7 +54,7 @@ export function axiosApiSendFile(url, body) {
     .post(url, formData, multipartFileHeader)
     .then((response) => response.data)
     .catch((error) => {
-      errorToast(error?.response?.data?.message)
+      toasts(error?.response?.data?.message)
       throw error
     })
 }
@@ -64,7 +64,7 @@ export function axiosApiDownloadFile(url, params) {
     .get(url, fileHeaderWithParams(params))
     .then((response) => response.data)
     .catch((error) => {
-      errorToast(error?.response?.data?.message)
+      toasts(error?.response?.data?.message)
       throw error
     })
 }
@@ -74,7 +74,7 @@ export function axiosApiGetFile(url, body) {
     .post(url, body, Object.assign(header, { responseType: 'blob' }))
     .then((response) => response.data)
     .catch((error) => {
-      errorToast(error?.response?.data?.message)
+      toasts(error?.response?.data?.message)
       throw error
     })
 }

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import authHeader from '../services/auth-header'
-import { toasts } from './toasts'
+import { errorToast } from './toasts'
 
 const header = Object.assign(authHeader(), { 'Content-Type': 'application/x-www-form-urlencoded' })
 const headerWithParams = (params) => Object.assign(header, { params })
@@ -12,7 +12,7 @@ export function axiosApiPost(url, body) {
     .post(url, body, header)
     .then((response) => response.data)
     .catch((error) => {
-      toasts(error?.response?.data?.message)
+      errorToast(error?.response?.data?.message)
       throw error
     })
 }
@@ -22,7 +22,7 @@ export function axiosApiGet(url, params) {
     .get(url, headerWithParams(params))
     .then((response) => response.data)
     .catch((error) => {
-      toasts(error?.response?.data?.message)
+      errorToast(error?.response?.data?.message)
       throw error
     })
 }
@@ -32,7 +32,7 @@ export function axiosApiDelete(url, params) {
     .delete(url, headerWithParams(params))
     .then((response) => response.data)
     .catch((error) => {
-      toasts(error?.response?.data?.message)
+      errorToast(error?.response?.data?.message)
       throw error
     })
 }
@@ -54,7 +54,7 @@ export function axiosApiSendFile(url, body) {
     .post(url, formData, multipartFileHeader)
     .then((response) => response.data)
     .catch((error) => {
-      toasts(error?.response?.data?.message)
+      errorToast(error?.response?.data?.message)
       throw error
     })
 }
@@ -64,7 +64,7 @@ export function axiosApiDownloadFile(url, params) {
     .get(url, fileHeaderWithParams(params))
     .then((response) => response.data)
     .catch((error) => {
-      toasts(error?.response?.data?.message)
+      errorToast(error?.response?.data?.message)
       throw error
     })
 }
@@ -74,7 +74,7 @@ export function axiosApiGetFile(url, body) {
     .post(url, body, Object.assign(header, { responseType: 'blob' }))
     .then((response) => response.data)
     .catch((error) => {
-      toasts(error?.response?.data?.message)
+      errorToast(error?.response?.data?.message)
       throw error
     })
 }

--- a/frontend/src/utils/errorToast.js
+++ b/frontend/src/utils/errorToast.js
@@ -1,4 +1,0 @@
-import { toast } from 'react-toastify'
-import 'react-toastify/dist/ReactToastify.css'
-
-export const errorToast = (errorMsg) => toast.error(errorMsg ?? 'Coś poszło nie tak.')

--- a/frontend/src/utils/toasts.js
+++ b/frontend/src/utils/toasts.js
@@ -4,7 +4,7 @@ import authService from '../services/auth.service'
 import { logout } from '../actions/auth'
 import { Button } from 'react-bootstrap'
 
-export const toasts = (errorMsg) => toast.error(errorMsg ?? 'Coś poszło nie tak.')
+export const errorToast = (errorMsg) => toast.error(errorMsg ?? 'Coś poszło nie tak.')
 
 const refreshSession = (user, dispatch, navigate) => {
   authService.refreshToken(user.refresh_token).catch(() => dispatch(logout(navigate)))

--- a/frontend/src/utils/toasts.js
+++ b/frontend/src/utils/toasts.js
@@ -1,0 +1,24 @@
+import { toast } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
+import authService from '../services/auth.service'
+import { logout } from '../actions/auth'
+import { Button } from 'react-bootstrap'
+
+export const toasts = (errorMsg) => toast.error(errorMsg ?? 'Coś poszło nie tak.')
+
+const refreshSession = (user, dispatch, navigate) => {
+  authService.refreshToken(user.refresh_token).catch(() => dispatch(logout(navigate)))
+}
+export const refreshSessionToast = (user, dispatch, navigate) =>
+  toast.warning(
+    <div className={'d-flex flex-column'}>
+      <p className={'text-center'}>Twoja sesja wygaśnie za mniej niż 15min.</p>
+      <Button variant={'outline-warning'} onClick={() => refreshSession(user, dispatch, navigate)}>
+        Wydłuż sesję
+      </Button>
+    </div>,
+    {
+      autoClose: false,
+      theme: 'dark'
+    }
+  )


### PR DESCRIPTION
W tym pr zmieniłem kilka ważnych rzeczy związanych z logowaniem. Po pierwsze gdy pierwszy raz react renderował aplikację to czasem przywitał nas ekran zalogowanego użytkownika i 500tka w konsoli. To dlatego że próbowaliśmy korzystając z danych z localStorage z dawna do refreshu tokena (który już sam wygasł). Teraz to działa tak, że gdy mamy mniej niż 15min do refresha to wyświetlamy komunikat w formie react-toastify "czy chcesz wydłużyć sesję". Jeżeli user przedłuży to okej, jak nie to zostanie wylogowany po 15min. Celowo token nie jest automatycznie zamykany - dzięki temu będzie się wyświetlał przy każdym przeładowaniu strony tak długo aż user będzie zalogowany i nie przedłuży tokena. Wydłużyć sesję można tylko z poziomu tego toast'a klikając w button.
Kolejna sprawa to naprawienie buga przy wylogowaniu. Korzystaliśmy z hooka useNavigate poza komponentem przez co konsola była cała czerwona po wylogowaniu, ale tego nie zauważaliśmy bo od razu ten navigate przekierował na stronę logowania więc wyczyścił całą konsolę. 
Kolejna rzecz to dodanie wylogowania ze wszystkich sesji gdy user wyloguje się z jednej. Tzn gdy user ma otwarte klika kart, na których jest zalogowany i wyloguje się na jednej z kart to zostaje automatycznie wylogowany na wszystkich pozostałych i przekierowany na stone logowania na każdej z nich.

Grzebałem chyba w najważniejszym serwisie całej aplikacji dlatego podrzucam wam wszystkim review dla pewności, że nic się nie zepsuło.

PS. nazwa brancha jest jaka jest bo na początku myślałem o wylogowywaniu usera gdy zamknie okno przeglądarki. Jednak okazało się, że to nie do zrobienia korzystając z cookiesów. (Z sessionStorage nie chcemy korzystać, to by nie miało żadnego sensu)