### PR TITLE
[SC-179] Endpoint do zmiany numeru indeksu (Student)

### DIFF
--- a/api/src/main/java/com/example/api/controller/user/UserController.java
+++ b/api/src/main/java/com/example/api/controller/user/UserController.java
@@ -15,10 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -90,5 +87,11 @@ public class UserController {
             @RequestBody SetStudentGroupForm setStudentGroupForm)
             throws EntityNotFoundException, WrongUserTypeException, StudentAlreadyAssignedToGroupException {
         return ResponseEntity.ok().body(userService.setStudentGroup(setStudentGroupForm));
+    }
+
+    @PostMapping("/user/index/set")
+    public ResponseEntity<Integer> setUserIndex(@RequestParam Integer newIndexNumber)
+            throws WrongUserTypeException, EntityAlreadyInDatabaseException {
+        return ResponseEntity.ok().body(userService.setIndexNumber(newIndexNumber));
     }
 }

--- a/api/src/test/java/com/example/api/unit/service/user/UserServiceTests.java
+++ b/api/src/test/java/com/example/api/unit/service/user/UserServiceTests.java
@@ -12,6 +12,7 @@ import com.example.api.repo.group.GroupRepo;
 import com.example.api.repo.user.UserRepo;
 import com.example.api.security.AuthenticationService;
 import com.example.api.service.user.UserService;
+import com.example.api.service.validator.UserValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +39,7 @@ public class UserServiceTests {
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private AuthenticationService authService;
     @Mock private Authentication authentication;
+    @Mock private UserValidator userValidator;
     @Captor private ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
     @Captor private ArgumentCaptor<Integer> integerArgumentCaptor = ArgumentCaptor.forClass(Integer.class);
     @Captor private ArgumentCaptor<Long> idArgumentCaptor = ArgumentCaptor.forClass(Long.class);
@@ -52,7 +54,7 @@ public class UserServiceTests {
     @BeforeEach
     public void init() {
         MockitoAnnotations.openMocks(this);
-        userService = new UserService(userRepo, groupRepo, authService, passwordEncoder);
+        userService = new UserService(userRepo, groupRepo, authService, passwordEncoder, userValidator);
 
         user = new User();
         user.setId(1L);


### PR DESCRIPTION
POST /user/index/set - zmienia studentowi nr indeksu jeśli nie jest on już zajęty przez innego studenta. Jeśli jest zajęty wyrzuca EntityAlreadyInDatabaseException. Endpoint zwraca numer nowego indeksu. Przy próbie zmiany indeksu na ten sam student otrzyma normalny response, tak jakby zmienił na inny numer.