### PR TITLE
[SC-201] Poprawki w endpoincie /list (podsumowanie z czego są punkty dla studenta w rankingu)

### DIFF
--- a/api/src/main/java/com/example/api/config/DatabaseConfig.java
+++ b/api/src/main/java/com/example/api/config/DatabaseConfig.java
@@ -1,5 +1,6 @@
 package com.example.api.config;
 
+import com.example.api.model.activity.result.AdditionalPoints;
 import com.example.api.model.activity.result.FileTaskResult;
 import com.example.api.model.activity.result.GraphTaskResult;
 import com.example.api.model.activity.task.FileTask;
@@ -20,6 +21,7 @@ import com.example.api.model.user.AccountType;
 import com.example.api.model.user.HeroType;
 import com.example.api.model.user.User;
 import com.example.api.model.util.Url;
+import com.example.api.repo.activity.result.AdditionalPointsRepo;
 import com.example.api.repo.map.ChapterRepo;
 import com.example.api.repo.util.UrlRepo;
 import com.example.api.service.activity.feedback.ProfessorFeedbackService;
@@ -53,6 +55,7 @@ import java.util.List;
 public class DatabaseConfig {
     private final UrlRepo urlRepo;
     private final ChapterRepo chapterRepo;
+    private final AdditionalPointsRepo additionalPointsRepo;
 
     @Bean
     public CommandLineRunner commandLineRunner(UserService userService, ProfessorFeedbackService professorFeedbackService,
@@ -471,6 +474,16 @@ public class DatabaseConfig {
             chapter.setActivityMap(activityMap1);
 
             chapterRepo.save(chapter);
+
+            AdditionalPoints additionalPoints = new AdditionalPoints();
+            additionalPoints.setId(1L);
+            additionalPoints.setUser(student);
+            additionalPoints.setPointsReceived(100D);
+            additionalPoints.setProfessorEmail(professor.getEmail());
+            additionalPoints.setDescription("Good job");
+            calendar.set(2022, Calendar.JUNE, 15);
+            additionalPoints.setSendDateMillis(calendar.getTimeInMillis());
+            additionalPointsRepo.save(additionalPoints);
         };
     }
 }

--- a/api/src/main/java/com/example/api/dto/response/activity/task/result/AdditionalPointsListResponse.java
+++ b/api/src/main/java/com/example/api/dto/response/activity/task/result/AdditionalPointsListResponse.java
@@ -1,0 +1,17 @@
+package com.example.api.dto.response.activity.task.result;
+
+import com.example.api.dto.response.map.task.ActivityType;
+import lombok.Data;
+
+@Data
+public class AdditionalPointsListResponse extends PointsResponse {
+
+    public AdditionalPointsListResponse(AdditionalPointsResponse additionalPointsResponse) {
+        super(
+                additionalPointsResponse.getDateMillis(),
+                additionalPointsResponse.getPoints(),
+                ActivityType.ADDITIONAL,
+                additionalPointsResponse.getDescription()
+        );
+    }
+}

--- a/api/src/main/java/com/example/api/dto/response/activity/task/result/AdditionalPointsResponse.java
+++ b/api/src/main/java/com/example/api/dto/response/activity/task/result/AdditionalPointsResponse.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class AdditionalPointsResponse implements PointsResponse {
+public class AdditionalPointsResponse {
     private Long dateMillis;
     private String professor;
     private Double points;

--- a/api/src/main/java/com/example/api/dto/response/activity/task/result/PointsResponse.java
+++ b/api/src/main/java/com/example/api/dto/response/activity/task/result/PointsResponse.java
@@ -1,6 +1,25 @@
 package com.example.api.dto.response.activity.task.result;
 
-public interface PointsResponse {
-    public Double getPoints();
-    public Long getDateMillis();
+import com.example.api.dto.response.map.task.ActivityType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.MappedSuperclass;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+public abstract class PointsResponse {
+    protected Long dateMillis;
+    protected Double pointsReceived;
+    protected ActivityType activityType;
+    protected String activityName;
+
+    public Long getDateMillis() {
+        return this.dateMillis;
+    }
 }

--- a/api/src/main/java/com/example/api/dto/response/activity/task/result/TaskPointsStatisticsResponse.java
+++ b/api/src/main/java/com/example/api/dto/response/activity/task/result/TaskPointsStatisticsResponse.java
@@ -9,25 +9,24 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class TaskPointsStatisticsResponse implements PointsResponse {
-    private Long dateMillis;
-    private Double pointsReceived;
-    private ActivityType activityType;
-    private String activityName;
+public class TaskPointsStatisticsResponse extends PointsResponse {
 
     public TaskPointsStatisticsResponse(GraphTaskResult result) {
+        super();
         setDateAndPoints(result.getSendDateMillis(), result.getPointsReceived());
         this.activityType = ActivityType.EXPEDITION;
         this.activityName = result.getGraphTask().getName();
     }
 
     public TaskPointsStatisticsResponse(FileTaskResult result) {
+        super();
         setDateAndPoints(result.getSendDateMillis(), result.getPointsReceived());
         this.activityType = ActivityType.TASK;
         this.activityName = result.getFileTask().getName();
     }
 
     public TaskPointsStatisticsResponse(SurveyResult result) {
+        super();
         setDateAndPoints(result.getSendDateMillis(), result.getPointsReceived());
         this.activityType = ActivityType.SURVEY;
         this.activityName = result.getSurvey().getName();
@@ -36,10 +35,5 @@ public class TaskPointsStatisticsResponse implements PointsResponse {
     private void setDateAndPoints(Long dateMillis, Double pointsReceived) {
         this.dateMillis = dateMillis;
         this.pointsReceived = pointsReceived;
-    }
-
-    @Override
-    public Double getPoints() {
-        return this.getPointsReceived();
     }
 }

--- a/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
@@ -1,12 +1,10 @@
 package com.example.api.service.activity.result;
 
+import com.example.api.dto.response.activity.task.result.AdditionalPointsListResponse;
 import com.example.api.dto.response.activity.task.result.AdditionalPointsResponse;
-import com.example.api.dto.response.activity.task.result.PointsResponse;
 import com.example.api.dto.response.activity.task.result.TaskPointsStatisticsResponse;
 import com.example.api.error.exception.WrongUserTypeException;
-import com.example.api.model.activity.result.AdditionalPoints;
 import com.example.api.model.user.User;
-import com.example.api.repo.activity.result.AdditionalPointsRepo;
 import com.example.api.repo.user.UserRepo;
 import com.example.api.security.AuthenticationService;
 import com.example.api.service.validator.UserValidator;
@@ -40,8 +38,12 @@ public class AllPointsService {
         log.info("Fetching student all points {} for professor {}", studentEmail, professorEmail);
         List<TaskPointsStatisticsResponse> taskPoints = taskResultService.getUserPointsStatistics(studentEmail);
         List<AdditionalPointsResponse> additionalPoints = additionalPointsService.getAdditionalPoints(studentEmail);
+        List<AdditionalPointsListResponse> additionalPointsList = additionalPoints
+                .stream()
+                .map(AdditionalPointsListResponse::new)
+                .toList();
 
-        return Stream.of(taskPoints, additionalPoints)
+        return Stream.of(taskPoints, additionalPointsList)
                 .flatMap(Collection::stream)
                 .sorted(((o1, o2) -> Long.compare(o2.getDateMillis(), o1.getDateMillis())))
                 .toList();


### PR DESCRIPTION
Teraz elementy listy z /points/all/list są zunifikowane. Zostawiłem pointsReceived jak coś. Przy sprawdzaniu możecie też spojrzeć na endpoint /task/result/points/statistics bo zmiany mogły wpłynąć na niego

- /points/all/list
<img width="337" alt="Zrzut ekranu 2022-08-21 o 23 20 33" src="https://user-images.githubusercontent.com/56938330/185811371-2ecc7c42-d9b1-4b26-b7e3-8f2e1af1a874.png">

- /task/result/points/statistics
<img width="339" alt="Zrzut ekranu 2022-08-21 o 23 24 41" src="https://user-images.githubusercontent.com/56938330/185811530-4ec45d26-de69-479f-b487-56a11810e638.png">

