### PR TITLE
[SC-145] Endpoint na aktualną liczbę punktów (total)

### DIFF
--- a/api/src/main/java/com/example/api/controller/activity/result/AllPointsController.java
+++ b/api/src/main/java/com/example/api/controller/activity/result/AllPointsController.java
@@ -1,5 +1,6 @@
 package com.example.api.controller.activity.result;
 
+import com.example.api.dto.response.activity.task.result.TotalPointsResponse;
 import com.example.api.error.exception.WrongUserTypeException;
 import com.example.api.service.activity.result.AllPointsService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -22,5 +23,10 @@ public class AllPointsController {
     @GetMapping("/list")
     public ResponseEntity<List<?>> getAllPointsList(@RequestParam String studentEmail) throws WrongUserTypeException {
         return ResponseEntity.ok().body(allPointsService.getAllPointsList(studentEmail));
+    }
+
+    @GetMapping("/total")
+    public ResponseEntity<TotalPointsResponse> getAllPointsTotal() throws WrongUserTypeException {
+        return ResponseEntity.ok().body(allPointsService.getAllPointsTotal());
     }
 }

--- a/api/src/main/java/com/example/api/dto/response/activity/task/result/TotalPointsResponse.java
+++ b/api/src/main/java/com/example/api/dto/response/activity/task/result/TotalPointsResponse.java
@@ -1,0 +1,11 @@
+package com.example.api.dto.response.activity.task.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TotalPointsResponse {
+    Double totalPointsReceived;
+    Double totalPointsPossibleToReceive;
+}

--- a/api/src/main/java/com/example/api/model/activity/result/GraphTaskResult.java
+++ b/api/src/main/java/com/example/api/model/activity/result/GraphTaskResult.java
@@ -31,8 +31,5 @@ public class GraphTaskResult extends TaskResult {
 
     private Long startDateMillis;
 
-    public Double getPointsReceived100() {
-        return super.getPointsReceived() * (graphTask.getMaxPoints100() / graphTask.getMaxPoints());
-    }
 }
 

--- a/api/src/main/java/com/example/api/model/activity/result/GraphTaskResult.java
+++ b/api/src/main/java/com/example/api/model/activity/result/GraphTaskResult.java
@@ -30,5 +30,9 @@ public class GraphTaskResult extends TaskResult {
     private int timeSpentSec;
 
     private Long startDateMillis;
+
+    public Double getPointsReceived100() {
+        return super.getPointsReceived() * (graphTask.getMaxPoints100() / graphTask.getMaxPoints());
+    }
 }
 

--- a/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
@@ -71,7 +71,7 @@ public class AllPointsService {
         graphTaskResultRepo.findAllByUser(student)
                 .forEach(graphTaskResult -> {
                     if (graphTaskResult.getGraphTask().getMaxPoints() > 0) {
-                        totalPointsReceived.updateAndGet(v -> v + graphTaskResult.getPointsReceived100());
+                        totalPointsReceived.updateAndGet(v -> v + graphTaskResult.getPointsReceived());
                         totalPointsToReceive.updateAndGet(v -> v + graphTaskResult.getGraphTask().getMaxPoints100());
                     }
                 });

--- a/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
@@ -92,7 +92,6 @@ public class AllPointsService {
                 .stream()
                 .forEach(additionalPoints -> {
                     totalPointsReceived.updateAndGet(v -> v + additionalPoints.getPointsReceived());
-                    totalPointsToReceive.updateAndGet(v -> v + additionalPoints.getPointsReceived());
                 });
         return new TotalPointsResponse(totalPointsReceived.get(), totalPointsToReceive.get());
     }

--- a/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/AllPointsService.java
@@ -70,8 +70,10 @@ public class AllPointsService {
         AtomicReference<Double> totalPointsToReceive = new AtomicReference<>(0D);
         graphTaskResultRepo.findAllByUser(student)
                 .forEach(graphTaskResult -> {
-                    totalPointsReceived.updateAndGet(v -> v + graphTaskResult.getPointsReceived());
-                    totalPointsToReceive.updateAndGet(v -> v + graphTaskResult.getGraphTask().getMaxPoints100());
+                    if (graphTaskResult.getGraphTask().getMaxPoints() > 0) {
+                        totalPointsReceived.updateAndGet(v -> v + graphTaskResult.getPointsReceived100());
+                        totalPointsToReceive.updateAndGet(v -> v + graphTaskResult.getGraphTask().getMaxPoints100());
+                    }
                 });
         fileTaskResultRepo.findAllByUser(student)
                 .stream()


### PR DESCRIPTION
Endpoint /points/all/total dla studenta wywołującego go zwraca liczbę zdobytych punktów (wszystkie aktywności: FileTask, GraphTask [brane pod uwagę jest ustawione 100% punktów], Survey, AdditionalPoints). Przy Survey i AdditionalPoints dodawana jest ta samo ilość punktów otrzymanych i możliwych do otrzymania. Takie przyjąłem założenia, ale można je zmienić.

<img width="430" alt="Zrzut ekranu 2022-08-24 o 21 08 26" src="https://user-images.githubusercontent.com/56938330/186502747-c99c5a2c-9a19-4678-b196-34a6d5616992.png">
 