### PR TITLE
[SC-208] Endpointy dla komponentu wyników studentów

### DIFF
--- a/api/src/main/java/com/example/api/config/DatabaseConfig.java
+++ b/api/src/main/java/com/example/api/config/DatabaseConfig.java
@@ -199,6 +199,14 @@ public class DatabaseConfig {
             student15.setIndexNumber(163456);
             student15.setHeroType(HeroType.ROGUE);
 
+            User student16 = new User("manowak@student.agh.edu.pl",
+                    "Małgorzata Anna",
+                    "Kowalska",
+                    AccountType.STUDENT);
+            student16.setPassword("12345");
+            student16.setIndexNumber(163457);
+            student16.setHeroType(HeroType.ROGUE);
+
             User professor = new User("bmaj@agh.edu.pl",
                     "Bernard",
                     "Maj",
@@ -216,7 +224,7 @@ public class DatabaseConfig {
             student.setIndexNumber(123456);
 
             List<User> students1 = List.of(student, student1, student2, student3, student4, student5, student6, student7);
-            List<User> students2 = List.of(student8, student9, student10, student11, student12, student13, student14, student15);
+            List<User> students2 = List.of(student8, student9, student10, student11, student12, student13, student14, student15, student16);
 
             Group group = new Group();
             group.setInvitationCode("1111");

--- a/api/src/main/java/com/example/api/controller/activity/result/ranking/RankingController.java
+++ b/api/src/main/java/com/example/api/controller/activity/result/ranking/RankingController.java
@@ -50,4 +50,17 @@ public class RankingController {
             throws WrongUserTypeException, MissingAttributeException, UsernameNotFoundException, EntityNotFoundException {
         return ResponseEntity.ok().body(rankingService.getGroupRankingPosition());
     }
+
+    @GetMapping("/activity")
+    public ResponseEntity<List<RankingResponse>> getAllPointsActivityList(@RequestParam Long activityID) throws WrongUserTypeException, EntityNotFoundException {
+        return ResponseEntity.ok().body(rankingService.getActivityRanking(activityID));
+    }
+
+    @GetMapping("/activity/search")
+    public ResponseEntity<List<RankingResponse>> getAllPointsActivityListSearch(
+            @RequestParam Long activityID,
+            @RequestParam String search
+    ) throws WrongUserTypeException, EntityNotFoundException {
+        return ResponseEntity.ok().body(rankingService.getActivityRankingSearch(activityID, search));
+    }
 }

--- a/api/src/main/java/com/example/api/model/activity/task/Activity.java
+++ b/api/src/main/java/com/example/api/model/activity/task/Activity.java
@@ -15,8 +15,9 @@ import javax.persistence.*;
 @AllArgsConstructor
 @MappedSuperclass
 public abstract class Activity {
+    @TableGenerator(name = "myGen", table = "ID_GEN", pkColumnName = "GEN_KEY", valueColumnName = "GEN_VALUE", pkColumnValue = "NEXT_ID", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "myGen")
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private String description;

--- a/api/src/main/java/com/example/api/repo/activity/result/FileTaskResultRepo.java
+++ b/api/src/main/java/com/example/api/repo/activity/result/FileTaskResultRepo.java
@@ -13,4 +13,5 @@ public interface FileTaskResultRepo extends JpaRepository<FileTaskResult, Long> 
     FileTaskResult findFileTaskResultById(Long id);
     FileTaskResult findFileTaskResultByFileTaskAndUser(FileTask fileTask, User user);
     List<FileTaskResult> findAllByUser(User user);
+    List<FileTaskResult> findAllByFileTask(FileTask fileTask);
 }

--- a/api/src/main/java/com/example/api/repo/activity/result/GraphTaskResultRepo.java
+++ b/api/src/main/java/com/example/api/repo/activity/result/GraphTaskResultRepo.java
@@ -13,4 +13,5 @@ public interface GraphTaskResultRepo extends JpaRepository<GraphTaskResult, Long
     GraphTaskResult findGraphTaskResultById(Long id);
     GraphTaskResult findGraphTaskResultByGraphTaskAndUser(GraphTask task, User user);
     List<GraphTaskResult> findAllByUser(User user);
+    List<GraphTaskResult> findAllByAndGraphTask(GraphTask graphTask);
 }

--- a/api/src/main/java/com/example/api/repo/activity/result/SurveyResultRepo.java
+++ b/api/src/main/java/com/example/api/repo/activity/result/SurveyResultRepo.java
@@ -13,4 +13,5 @@ public interface SurveyResultRepo extends JpaRepository<SurveyResult, Long> {
     List<SurveyResult> findAllByUser(User user);
     SurveyResult findSurveyResultById(Long id);
     SurveyResult findSurveyResultBySurveyAndUser(Survey survey, User user);
+    List<SurveyResult> findAllBySurvey(Survey survey);
 }

--- a/api/src/main/java/com/example/api/service/activity/result/ranking/RankingService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/ranking/RankingService.java
@@ -85,8 +85,8 @@ public class RankingService {
         List<RankingResponse> rankingList = userRepo.findAllByAccountTypeEquals(AccountType.STUDENT)
                 .stream()
                 .filter(student ->
-                                student.getFirstName().concat(student.getLastName()).toLowerCase().contains(searchLower) ||
-                                student.getLastName().concat(student.getFirstName()).toLowerCase().contains(searchLower) ||
+                                student.getFirstName().concat(student.getLastName()).toLowerCase().replaceAll("\\s","").contains(searchLower) ||
+                                student.getLastName().concat(student.getFirstName()).toLowerCase().replaceAll("\\s","").contains(searchLower) ||
                                 student.getHeroType().getPolishTypeName().toLowerCase().contains(searchLower) ||
                                 student.getGroup().getName().toLowerCase().contains(searchLower))
                 .map(this::studentToRankingEntry)
@@ -115,8 +115,8 @@ public class RankingService {
         List<RankingResponse> rankingList = getActivityRanking(activityID)
                 .stream()
                 .filter(student ->
-                            student.getFirstName().concat(student.getLastName()).toLowerCase().contains(searchLower) ||
-                            student.getLastName().concat(student.getFirstName()).toLowerCase().contains(searchLower) ||
+                            student.getFirstName().concat(student.getLastName()).toLowerCase().replaceAll("\\s","").contains(searchLower) ||
+                            student.getLastName().concat(student.getFirstName()).toLowerCase().replaceAll("\\s","").contains(searchLower) ||
                             student.getHeroType().getPolishTypeName().toLowerCase().contains(searchLower) ||
                             student.getGroupName().toLowerCase().contains(searchLower)
                 )

--- a/api/src/main/java/com/example/api/service/activity/result/ranking/RankingService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/ranking/RankingService.java
@@ -81,12 +81,12 @@ public class RankingService {
     }
 
     public List<RankingResponse> getSearchedRanking(String search) {
-        String searchLower = search.toLowerCase();
+        String searchLower = search.toLowerCase().replaceAll("\\s",""); // removing whitespaces
         List<RankingResponse> rankingList = userRepo.findAllByAccountTypeEquals(AccountType.STUDENT)
                 .stream()
                 .filter(student ->
-                        student.getFirstName().toLowerCase().contains(searchLower) ||
-                                student.getLastName().toLowerCase().contains(searchLower) ||
+                                student.getFirstName().concat(student.getLastName()).toLowerCase().contains(searchLower) ||
+                                student.getLastName().concat(student.getFirstName()).toLowerCase().contains(searchLower) ||
                                 student.getHeroType().getPolishTypeName().toLowerCase().contains(searchLower) ||
                                 student.getGroup().getName().toLowerCase().contains(searchLower))
                 .map(this::studentToRankingEntry)
@@ -111,14 +111,14 @@ public class RankingService {
     }
 
     public List<RankingResponse> getActivityRankingSearch(Long activityID, String search) throws WrongUserTypeException, EntityNotFoundException {
-        String searchLower = search.toLowerCase();
+        String searchLower = search.toLowerCase().replaceAll("\\s",""); // removing whitespaces
         List<RankingResponse> rankingList = getActivityRanking(activityID)
                 .stream()
-                .filter(rankingResponse ->
-                    rankingResponse.getFirstName().toLowerCase().equals(searchLower) ||
-                            rankingResponse.getLastName().toLowerCase().equals(searchLower) ||
-                            rankingResponse.getHeroType().getPolishTypeName().toLowerCase().equals(searchLower) ||
-                            rankingResponse.getGroupName().toLowerCase().equals(searchLower)
+                .filter(student ->
+                            student.getFirstName().concat(student.getLastName()).toLowerCase().contains(searchLower) ||
+                            student.getLastName().concat(student.getFirstName()).toLowerCase().contains(searchLower) ||
+                            student.getHeroType().getPolishTypeName().toLowerCase().contains(searchLower) ||
+                            student.getGroupName().toLowerCase().contains(searchLower)
                 )
                 .sorted(Comparator.comparingDouble(RankingResponse::getPoints).reversed())
                 .toList();


### PR DESCRIPTION
Dwa endpointy dla prowadzącego:

- /ranking/acitvity - podajemy activityID i dostajemy listę wszystkich studentów, liczbę punktów za activity itd.
<img width="472" alt="Zrzut ekranu 2022-08-26 o 23 15 38" src="https://user-images.githubusercontent.com/56938330/186991749-cabb43c6-4f3d-4eb9-b283-153d001afecc.png">

- /ranking/activity/search - podajemy activityID i search i dostajemy przefiltrowane wyniki z /ranking/activity
<img width="560" alt="Zrzut ekranu 2022-08-26 o 23 16 06" src="https://user-images.githubusercontent.com/56938330/186991795-354b27a7-7245-41cd-b0b9-1c8bde4c64e3.png">

Endpointy zwracają ten sam rodzaj wartości co pozostałe endpointy rankingowe 
