### PR TITLE
[SC-158] Endpoint do dodania nowego rozdziału

### DIFF
--- a/api/src/main/java/com/example/api/config/DatabaseConfig.java
+++ b/api/src/main/java/com/example/api/config/DatabaseConfig.java
@@ -21,10 +21,12 @@ import com.example.api.model.question.QuestionType;
 import com.example.api.model.user.AccountType;
 import com.example.api.model.user.HeroType;
 import com.example.api.model.user.User;
+import com.example.api.model.util.File;
 import com.example.api.model.util.Url;
 import com.example.api.repo.activity.result.AdditionalPointsRepo;
 import com.example.api.repo.activity.result.SurveyResultRepo;
 import com.example.api.repo.map.ChapterRepo;
+import com.example.api.repo.util.FileRepo;
 import com.example.api.repo.util.UrlRepo;
 import com.example.api.service.activity.feedback.ProfessorFeedbackService;
 import com.example.api.service.activity.feedback.UserFeedbackService;
@@ -59,6 +61,7 @@ public class DatabaseConfig {
     private final ChapterRepo chapterRepo;
     private final AdditionalPointsRepo additionalPointsRepo;
     private final SurveyResultRepo surveyResultRepo;
+    private final FileRepo fileRepo;
 
     @Bean
     public CommandLineRunner commandLineRunner(UserService userService, ProfessorFeedbackService professorFeedbackService,
@@ -523,6 +526,9 @@ public class DatabaseConfig {
             calendar.set(2022, Calendar.JUNE, 19);
             surveyResult3.setSendDateMillis(calendar.getTimeInMillis());
             surveyResultRepo.save(surveyResult3);
+
+            File file = new File();
+            fileRepo.save(file);
         };
     }
 }

--- a/api/src/main/java/com/example/api/controller/map/ChapterController.java
+++ b/api/src/main/java/com/example/api/controller/map/ChapterController.java
@@ -1,15 +1,15 @@
 package com.example.api.controller.map;
 
+import com.example.api.dto.request.map.ChapterForm;
 import com.example.api.dto.response.map.ChapterInfoResponse;
 import com.example.api.dto.response.map.ChapterResponse;
+import com.example.api.error.exception.EntityNotFoundException;
 import com.example.api.service.map.ChapterService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,7 +26,13 @@ public class ChapterController {
     }
 
     @GetMapping("/info")
-    public ResponseEntity<ChapterInfoResponse> getChapterInfo(@RequestParam Long id) {
+    public ResponseEntity<ChapterInfoResponse> getChapterInfo(@RequestParam Long id) throws EntityNotFoundException {
         return ResponseEntity.ok().body(chapterService.getChapterInfo(id));
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<?> createChapter(@RequestBody ChapterForm form) throws EntityNotFoundException {
+        chapterService.createChapter(form);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/api/src/main/java/com/example/api/dto/request/map/ChapterForm.java
+++ b/api/src/main/java/com/example/api/dto/request/map/ChapterForm.java
@@ -1,0 +1,15 @@
+package com.example.api.dto.request.map;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChapterForm {
+    private String name;
+    private Integer sizeX;
+    private Integer sizeY;
+    private Long imageId;
+}

--- a/api/src/main/java/com/example/api/model/map/ActivityMap.java
+++ b/api/src/main/java/com/example/api/model/map/ActivityMap.java
@@ -4,6 +4,7 @@ import com.example.api.model.activity.task.FileTask;
 import com.example.api.model.activity.task.GraphTask;
 import com.example.api.model.activity.task.Info;
 import com.example.api.model.activity.task.Survey;
+import com.example.api.model.util.File;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,4 +38,13 @@ public class ActivityMap {
 
     private Integer mapSizeX;
     private Integer mapSizeY;
+
+    @OneToOne
+    private File image;
+
+    public ActivityMap(int mapSizeX, int mapSizeY, File image) {
+        this.mapSizeX = mapSizeX;
+        this.mapSizeY = mapSizeY;
+        this.image = image;
+    }
 }

--- a/api/src/main/java/com/example/api/model/map/Chapter.java
+++ b/api/src/main/java/com/example/api/model/map/Chapter.java
@@ -29,6 +29,11 @@ public class Chapter {
     @OneToOne
     private ActivityMap activityMap;
 
+    public Chapter(String name, ActivityMap activityMap) {
+        this.name = name;
+        this.activityMap = activityMap;
+    }
+
     public int getNoActivities() {
         return activityMap.getGraphTasks().size() + activityMap.getFileTasks().size() +
                 activityMap.getInfos().size() + activityMap.getSurveys().size();

--- a/api/src/main/java/com/example/api/service/map/ChapterService.java
+++ b/api/src/main/java/com/example/api/service/map/ChapterService.java
@@ -1,10 +1,17 @@
 package com.example.api.service.map;
 
+import com.example.api.dto.request.map.ChapterForm;
 import com.example.api.dto.response.map.ChapterInfoResponse;
 import com.example.api.dto.response.map.ChapterResponse;
 import com.example.api.dto.response.map.task.MapTask;
+import com.example.api.error.exception.EntityNotFoundException;
+import com.example.api.model.map.ActivityMap;
 import com.example.api.model.map.Chapter;
+import com.example.api.model.util.File;
 import com.example.api.repo.map.ChapterRepo;
+import com.example.api.repo.util.FileRepo;
+import com.example.api.service.validator.ActivityValidator;
+import com.example.api.service.validator.MapValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,15 +26,38 @@ import java.util.List;
 public class ChapterService {
     private final ChapterRepo chapterRepo;
     private final ActivityMapService activityMapService;
+    private final FileRepo fileRepo;
+    private final MapValidator mapValidator;
+    private final ActivityValidator activityValidator;
 
     public List<ChapterResponse> getAllChapters() {
+        log.info("Fetching all chapters");
         List<Chapter> chapters = chapterRepo.findAll();
         return chapters.stream().map(ChapterResponse::new).toList();
     }
 
-    public ChapterInfoResponse getChapterInfo(Long id) {
+    public ChapterInfoResponse getChapterInfo(Long id) throws EntityNotFoundException {
+        log.info("Fetching info for chapter with id {}", id);
         Chapter chapter = chapterRepo.findChapterById(id);
+        mapValidator.validateChapterIsNotNull(chapter, id);
         List<MapTask> allTasks = activityMapService.getMapTasks(chapter.getActivityMap());
         return new ChapterInfoResponse(chapter, allTasks);
+    }
+
+    public void createChapter(ChapterForm form) throws EntityNotFoundException {
+        File image = fileRepo.findFileById(form.getImageId());
+        activityValidator.validateFileIsNotNull(image, form.getImageId());
+        ActivityMap activityMap = new ActivityMap(form.getSizeX(), form.getSizeY(), image);
+        activityMapService.saveActivityMap(activityMap);
+        Chapter chapter = new Chapter(form.getName(), activityMap);
+        List<Chapter> allChapters = chapterRepo.findAll();
+        chapterRepo.save(chapter);
+        if (!allChapters.isEmpty()) {
+            allChapters.forEach(chapter_ -> {
+                if (chapter_.getNextChapter() == null) {
+                    chapter_.setNextChapter(chapter);
+                }
+             });
+        }
     }
 }

--- a/api/src/main/java/com/example/api/service/validator/MapValidator.java
+++ b/api/src/main/java/com/example/api/service/validator/MapValidator.java
@@ -2,6 +2,7 @@ package com.example.api.service.validator;
 
 import com.example.api.error.exception.EntityNotFoundException;
 import com.example.api.model.map.ActivityMap;
+import com.example.api.model.map.Chapter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,13 @@ public class MapValidator {
         if(activityMap == null) {
             log.error("ActivityMap with id {} not found in database", id);
             throw new EntityNotFoundException("ActivityMap with id" + id + " not found in database");
+        }
+    }
+
+    public void validateChapterIsNotNull(Chapter chapter, Long id) throws EntityNotFoundException {
+        if(chapter == null) {
+            log.error("Chapter with id {} not found in database", id);
+            throw new EntityNotFoundException("Chapter with id" + id + " not found in database");
         }
     }
 }


### PR DESCRIPTION
Dodałem endpointa do dodania nowego rozdziału (no i przy okazji ActivityMap).

/api/chapter/create

Przyjmuje on obiekt w postaci:
{
    "name": "",
    "sizeX": ,
    "sizeY": ,
    "imageId": 
}

Gdzie imageId to id wybranego przez prowadzecego zdjęcia, które będzie w bazie wcześniej.

W chapterze mamy pole nextChapter, które aktualnie ustawiam tak:
1. Wyszukuje wszystkie chaptery
2. Dla tych które maja null ustawian nextChapter jako ten który aktualnie jest tworzony

Czyli po prostu dodając po kolei chaptery, automatycznie się będzie ustawiał nextChapter dla wcześniejszego chaptera na tego utworzonego właśnie teraz.

Jeżeli chodzi o requirementy to na razie dałem, że daje się null w to pole. Musimy rozkminić jak będą dodawane te requirementy i wtedy zrobimy jakiś mechanizm dodawania ich.