### PR TITLE
Sc 218 zbudowanie widoku wytycznych od nowa

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9633,6 +9633,11 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
         },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11366,6 +11371,15 @@
                 "scheduler": "^0.22.0"
             }
         },
+        "react-draggable": {
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+            "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+            "requires": {
+                "clsx": "^1.1.1",
+                "prop-types": "^15.8.1"
+            }
+        },
         "react-error-overlay": {
             "version": "6.0.11",
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -11375,6 +11389,18 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
             "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "react-grid-layout": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.3.4.tgz",
+            "integrity": "sha512-sB3rNhorW77HUdOjB4JkelZTdJGQKuXLl3gNg+BI8gJkTScspL1myfZzW/EM0dLEn+1eH+xW+wNqk0oIM9o7cw==",
+            "requires": {
+                "clsx": "^1.1.1",
+                "lodash.isequal": "^4.0.0",
+                "prop-types": "^15.8.1",
+                "react-draggable": "^4.0.0",
+                "react-resizable": "^3.0.4"
+            }
         },
         "react-is": {
             "version": "17.0.2",
@@ -11418,6 +11444,15 @@
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
             "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+        },
+        "react-resizable": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.4.tgz",
+            "integrity": "sha512-StnwmiESiamNzdRHbSSvA65b0ZQJ7eVQpPusrSmcpyGKzC0gojhtO62xxH6YOBmepk9dQTBi9yxidL3W4s3EBA==",
+            "requires": {
+                "prop-types": "15.x",
+                "react-draggable": "^4.0.3"
+            }
         },
         "react-router": {
             "version": "6.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
         "react-bootstrap": "^2.5.0",
         "react-chartjs-2": "^4.3.1",
         "react-dom": "^18.1.0",
+        "react-grid-layout": "^1.3.4",
         "react-json-editor-ajrm": "^2.5.13",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",

--- a/frontend/src/components/general/ImagesGallery/ImagesGallery.js
+++ b/frontend/src/components/general/ImagesGallery/ImagesGallery.js
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react'
+import GridLayout from 'react-grid-layout'
+
+function ImagesGallery(props) {
+  const [imagesHeight, setImagesHeight] = useState([])
+  const [rowHeight, setRowHeight] = useState(undefined)
+  const [layout, setLayout] = useState(undefined)
+
+  useEffect(() => {
+    setImagesHeight(Array(props.images.length).fill(0))
+
+    props.images.forEach((url, index) => {
+      const img = new Image()
+      img.src = url
+      img.onload = (e) => {
+        const scaledWidth = Math.floor(props.width / props.cols)
+        const scaledHeight = Math.floor((e.target.height * scaledWidth) / e.target.width)
+
+        setImagesHeight((prevState) => prevState.map((value, i) => (i === index ? scaledHeight : value)))
+      }
+    })
+  }, [props])
+
+  useEffect(() => {
+    if (!imagesHeight.includes(0)) {
+      setRowHeight(...imagesHeight)
+    }
+  }, [imagesHeight])
+
+  useEffect(() => {
+    if (rowHeight) {
+      const layoutConfig = props.images.map((url, index) => {
+        const rowNumber = props.cols > 0 ? Math.floor(index / props.cols) : 1
+
+        return {
+          i: index.toString(),
+          x: index % props.cols,
+          y: index >= props.cols ? imagesHeight[index - props.cols] + rowNumber : 0,
+          w: 1,
+          h: imagesHeight[index] > 0 && rowHeight > 0 ? Math.ceil(imagesHeight[index] / rowHeight) : 1
+        }
+      })
+
+      setLayout(layoutConfig)
+    }
+  }, [rowHeight, imagesHeight, props.images, props.cols])
+
+  return (
+    layout &&
+    rowHeight && (
+      <GridLayout
+        className={'layout'}
+        layout={layout}
+        cols={props.cols}
+        width={props.width}
+        rowHeight={rowHeight > 0 ? rowHeight : props.width}
+      >
+        {props.images.map((url, index) => (
+          <div key={index.toString()}>
+            <img width={'100%'} height={'100%'} src={url} alt={'info-task-attachment'} />
+          </div>
+        ))}
+      </GridLayout>
+    )
+  )
+}
+
+export default ImagesGallery

--- a/frontend/src/components/general/ImagesGallery/ImagesGallery.js
+++ b/frontend/src/components/general/ImagesGallery/ImagesGallery.js
@@ -1,10 +1,17 @@
 import React, { useEffect, useState } from 'react'
 import GridLayout from 'react-grid-layout'
+import { ControlPanel, ImageContainer } from './ImagesGalleryStyle'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronLeft, faChevronRight, faEllipsisVertical } from '@fortawesome/free-solid-svg-icons'
+import { Button, Dropdown, Modal, ModalBody, ModalFooter, ModalHeader } from 'react-bootstrap'
+import download from 'downloadjs'
 
 function ImagesGallery(props) {
   const [imagesHeight, setImagesHeight] = useState([])
   const [rowHeight, setRowHeight] = useState(undefined)
   const [layout, setLayout] = useState(undefined)
+  const [isFullPreviewOpen, setIsFullPreviewOpen] = useState(false)
+  const [fullPreviewSource, setFullPreviewSource] = useState({})
 
   useEffect(() => {
     setImagesHeight(Array(props.images.length).fill(0))
@@ -45,23 +52,90 @@ function ImagesGallery(props) {
     }
   }, [rowHeight, imagesHeight, props.images, props.cols])
 
+  const openFullPreview = (e, url, index) => {
+    e.stopPropagation()
+    setIsFullPreviewOpen(true)
+    setFullPreviewSource({ src: url, id: index, isFirst: index === 0, isLast: index === props.images.length })
+  }
+
+  const downloadFile = (e, url) => {
+    e.stopPropagation()
+    download(url)
+  }
+
+  const nextImage = (index) => {
+    const nextImageId = Math.min(props.images.length - 1, index + 1)
+    const isLast = nextImageId === props.images.length - 1
+    setFullPreviewSource({ id: nextImageId, src: props.images[nextImageId], isFirst: false, isLast: isLast })
+  }
+
+  const prevImage = (index) => {
+    const prevImageId = Math.max(0, index - 1)
+    const isFirst = prevImageId === 0
+    setFullPreviewSource({ id: prevImageId, src: props.images[prevImageId], isFirst: isFirst, isLast: false })
+  }
+
   return (
-    layout &&
-    rowHeight && (
-      <GridLayout
-        className={'layout'}
-        layout={layout}
-        cols={props.cols}
-        width={props.width}
-        rowHeight={rowHeight > 0 ? rowHeight : props.width}
-      >
-        {props.images.map((url, index) => (
-          <div key={index.toString()}>
-            <img width={'100%'} height={'100%'} src={url} alt={'info-task-attachment'} />
-          </div>
-        ))}
-      </GridLayout>
-    )
+    <>
+      {layout && rowHeight && (
+        <GridLayout
+          className={'layout'}
+          layout={layout}
+          cols={props.cols}
+          width={props.width}
+          rowHeight={rowHeight > 0 ? rowHeight : props.width}
+          isDraggable={false}
+        >
+          {props.images.map((url, index) => (
+            <ImageContainer key={index.toString()} className={'rounded'}>
+              <img className={'p-3'} width={'100%'} height={'100%'} src={url} alt={'info-task-attachment'} />
+
+              <ControlPanel drop={'start'}>
+                <Dropdown.Toggle variant='warning'>
+                  <FontAwesomeIcon icon={faEllipsisVertical} />
+                </Dropdown.Toggle>
+                <Dropdown.Menu>
+                  <Dropdown.Item onClick={(e) => openFullPreview(e, url, index)}>Pełny podgląd</Dropdown.Item>
+                  <Dropdown.Item onClick={(e) => downloadFile(e, url)}>Pobierz</Dropdown.Item>
+                </Dropdown.Menu>
+              </ControlPanel>
+            </ImageContainer>
+          ))}
+        </GridLayout>
+      )}
+
+      <Modal show={isFullPreviewOpen} onHide={() => setIsFullPreviewOpen(false)} size={'xl'}>
+        <ModalHeader closeButton>
+          <h5>Pełny podgląd plików</h5>
+        </ModalHeader>
+        <ModalBody className={'d-flex justify-content-center align-items-center'}>
+          <FontAwesomeIcon
+            icon={faChevronLeft}
+            className={'display-3 me-5'}
+            onClick={() => {
+              if (!fullPreviewSource.isFirst) {
+                prevImage(fullPreviewSource.id)
+              }
+            }}
+            style={{ opacity: fullPreviewSource.isFirst ? 0.5 : 1, cursor: 'pointer' }}
+          />
+          <img height={'100%'} src={fullPreviewSource.src} alt={'full-preview'} />
+          <FontAwesomeIcon
+            icon={faChevronRight}
+            className={'display-3 ms-5'}
+            onClick={() => {
+              if (!fullPreviewSource.isLast) {
+                nextImage(fullPreviewSource.id)
+              }
+            }}
+            style={{ opacity: fullPreviewSource.isLast ? 0.5 : 1, cursor: 'pointer' }}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={() => setIsFullPreviewOpen(false)}>Zamknij</Button>
+        </ModalFooter>
+      </Modal>
+    </>
   )
 }
 

--- a/frontend/src/components/general/ImagesGallery/ImagesGalleryStyle.js
+++ b/frontend/src/components/general/ImagesGallery/ImagesGalleryStyle.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+import { Dropdown } from 'react-bootstrap'
+
+export const ImageContainer = styled.div`
+  border: 1px solid rgba(255, 179, 16, 0.5);
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+export const ControlPanel = styled(Dropdown)`
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  .dropdown-toggle::before {
+    display: none !important;
+  }
+`

--- a/frontend/src/components/student/AllActivities/InfoTask/Information.js
+++ b/frontend/src/components/student/AllActivities/InfoTask/Information.js
@@ -8,7 +8,7 @@ import InfoTaskService from '../../../../services/infoTask.service'
 import { Card, Col, Row } from 'react-bootstrap'
 import { CustomCard } from '../../GameCardPage/GameCardStyles'
 import CardHeader from 'react-bootstrap/CardHeader'
-import GridLayout from 'react-grid-layout'
+import ImagesGallery from '../../../general/ImagesGallery/ImagesGallery'
 
 export default function Information() {
   const location = useLocation()
@@ -65,82 +65,17 @@ export default function Information() {
       return <p>{ERROR_OCCURRED}</p>
     }
 
-    const images = information.imageUrls.concat([...information.imageUrls, ...information.imageUrls])
-
-    const imagesNumber = images.length
-    const parentWidth = gridCardRef.current.offsetWidth - 32
-    const parentHeight = gridCardRef.current.offsetHeight - 50
-    const imagesNumberInOneRow = 3
-    const rowsNumber = Math.ceil(imagesNumber / 3)
-
-    const imagesHeight = []
-    images.forEach((url) => {
-      const imgTemplate = document.createElement('img')
-      imgTemplate.src = url
-      const originalWidth = imgTemplate.width
-      const originalHeight = imgTemplate.height
-      const scaledWidth = Math.floor(parentWidth / imagesNumberInOneRow)
-      const scaledHeight = Math.floor((originalHeight * scaledWidth) / originalWidth)
-
-      imagesHeight.push(scaledHeight)
-    })
-
-    const rowHeight = Math.min(...imagesHeight)
-    console.log(rowHeight)
-
-    // const layout = [
-    //   { i: '0', x: 0, y: 0, w: 1, h: 2 },
-    //   { i: '1', x: 1, y: 0, w: 3, h: 2 },
-    //   { i: '2', x: 4, y: 0, w: 1, h: 2 }
-    // ]
-    // return (
-    //   <GridLayout className='layout' layout={layout} cols={12} rowHeight={30} width={1200}>
-    //     <div key='0' style={{ background: 'red' }}>
-    //       a
-    //     </div>
-    //     <div key='1' style={{ background: 'red' }}>
-    //       b
-    //     </div>
-    //     <div key='2' style={{ background: 'red' }}>
-    //       c
-    //     </div>
-    //   </GridLayout>
-    // )
-
-    const layout = images.map((url, index) => {
-      const rowNumber = Math.floor(index / imagesNumberInOneRow)
-
-      console.log(
-        index.toString(),
-        index % imagesNumberInOneRow,
-        index >= imagesNumberInOneRow ? imagesHeight[index - imagesNumberInOneRow] + rowNumber : 0,
-        Math.ceil(imagesHeight[index] / rowHeight)
+    if (gridCardRef.current?.offsetWidth) {
+      return (
+        <ImagesGallery
+          width={gridCardRef.current.offsetWidth - 32}
+          images={information.imageUrls.concat([...information.imageUrls, ...information.imageUrls])}
+          cols={3}
+        />
       )
+    }
 
-      return {
-        i: index.toString(),
-        x: index % imagesNumberInOneRow,
-        y: index >= imagesNumberInOneRow ? imagesHeight[index - imagesNumberInOneRow] + rowNumber : 0,
-        w: 1,
-        h: Math.ceil(imagesHeight[index] / rowHeight) //Math.round(imgTemplate.height / imgTemplate.width)
-      }
-    })
-
-    return (
-      <GridLayout
-        className={'layout'}
-        layout={layout}
-        cols={imagesNumberInOneRow}
-        width={parentWidth}
-        rowHeight={rowHeight}
-      >
-        {images.map((url, index) => (
-          <div key={index.toString()}>
-            <img width={'100%'} height={'100%'} src={url} alt={'info-task-attachment'} />
-          </div>
-        ))}
-      </GridLayout>
-    )
+    return <></>
   }, [information])
 
   return (

--- a/frontend/src/components/student/AllActivities/InfoTask/Information.js
+++ b/frontend/src/components/student/AllActivities/InfoTask/Information.js
@@ -1,27 +1,21 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Activity, ERROR_OCCURRED, getActivityImg, getActivityTypeName } from '../../../../utils/constants'
-import {
-  ActivityCol,
-  ActivityImg,
-  ActivityName,
-  ActivityType,
-  FullDivider,
-  HeaderCol,
-  HeaderRow,
-  SmallDivider
-} from '../ExpeditionTask/ActivityInfo/ActivityInfoStyles'
-import { InfoContainer } from '../ExpeditionTask/ActivityInfo/InfoContainer'
 import { Content } from '../../../App/AppGeneralStyles'
-import { InformationImage } from './InformationStyles'
+import { InformationTable } from './InformationStyles'
 import Loader from '../../../general/Loader/Loader'
 import InfoTaskService from '../../../../services/infoTask.service'
+import { Card, Col, Row } from 'react-bootstrap'
+import { CustomCard } from '../../GameCardPage/GameCardStyles'
+import CardHeader from 'react-bootstrap/CardHeader'
+import GridLayout from 'react-grid-layout'
 
 export default function Information() {
   const location = useLocation()
   const { activityId: informationId } = location.state
 
   const [information, setInformation] = useState(undefined)
+  const gridCardRef = useRef()
 
   useEffect(() => {
     InfoTaskService.getInformation(informationId)
@@ -29,37 +23,164 @@ export default function Information() {
       .catch(() => setInformation(null))
   }, [informationId])
 
+  const activityInfoCardBody = useMemo(() => {
+    if (information === undefined) {
+      return <Loader />
+    }
+    if (information == null) {
+      return <p>{ERROR_OCCURRED}</p>
+    }
+
+    const tableElements = [
+      { name: 'Typ aktywności', value: getActivityTypeName(Activity.INFO) },
+      { name: 'Nazwa', value: information.name },
+      { name: 'Opis', value: 'Tutaj będzie krótki opis gdy backend to doda' }
+    ]
+
+    return (
+      <InformationTable>
+        <tbody>
+          <tr>
+            <td>Ikonka aktywności:</td>
+            <td>
+              <img height={45} src={getActivityImg(Activity.INFO)} alt={'info-task-icon'} />
+            </td>
+          </tr>
+          {tableElements.map((element, index) => (
+            <tr key={index + Date.now()}>
+              <td>{element.name}:</td>
+              <td>{element.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </InformationTable>
+    )
+  }, [information])
+
+  const imagesGridLayout = useMemo(() => {
+    if (information === undefined) {
+      return <Loader />
+    }
+    if (information === null) {
+      return <p>{ERROR_OCCURRED}</p>
+    }
+
+    const images = information.imageUrls.concat([...information.imageUrls, ...information.imageUrls])
+
+    const imagesNumber = images.length
+    const parentWidth = gridCardRef.current.offsetWidth - 32
+    const parentHeight = gridCardRef.current.offsetHeight - 50
+    const imagesNumberInOneRow = 3
+    const rowsNumber = Math.ceil(imagesNumber / 3)
+
+    const imagesHeight = []
+    images.forEach((url) => {
+      const imgTemplate = document.createElement('img')
+      imgTemplate.src = url
+      const originalWidth = imgTemplate.width
+      const originalHeight = imgTemplate.height
+      const scaledWidth = Math.floor(parentWidth / imagesNumberInOneRow)
+      const scaledHeight = Math.floor((originalHeight * scaledWidth) / originalWidth)
+
+      imagesHeight.push(scaledHeight)
+    })
+
+    const rowHeight = Math.min(...imagesHeight)
+    console.log(rowHeight)
+
+    // const layout = [
+    //   { i: '0', x: 0, y: 0, w: 1, h: 2 },
+    //   { i: '1', x: 1, y: 0, w: 3, h: 2 },
+    //   { i: '2', x: 4, y: 0, w: 1, h: 2 }
+    // ]
+    // return (
+    //   <GridLayout className='layout' layout={layout} cols={12} rowHeight={30} width={1200}>
+    //     <div key='0' style={{ background: 'red' }}>
+    //       a
+    //     </div>
+    //     <div key='1' style={{ background: 'red' }}>
+    //       b
+    //     </div>
+    //     <div key='2' style={{ background: 'red' }}>
+    //       c
+    //     </div>
+    //   </GridLayout>
+    // )
+
+    const layout = images.map((url, index) => {
+      const rowNumber = Math.floor(index / imagesNumberInOneRow)
+
+      console.log(
+        index.toString(),
+        index % imagesNumberInOneRow,
+        index >= imagesNumberInOneRow ? imagesHeight[index - imagesNumberInOneRow] + rowNumber : 0,
+        Math.ceil(imagesHeight[index] / rowHeight)
+      )
+
+      return {
+        i: index.toString(),
+        x: index % imagesNumberInOneRow,
+        y: index >= imagesNumberInOneRow ? imagesHeight[index - imagesNumberInOneRow] + rowNumber : 0,
+        w: 1,
+        h: Math.ceil(imagesHeight[index] / rowHeight) //Math.round(imgTemplate.height / imgTemplate.width)
+      }
+    })
+
+    return (
+      <GridLayout
+        className={'layout'}
+        layout={layout}
+        cols={imagesNumberInOneRow}
+        width={parentWidth}
+        rowHeight={rowHeight}
+      >
+        {images.map((url, index) => (
+          <div key={index.toString()}>
+            <img width={'100%'} height={'100%'} src={url} alt={'info-task-attachment'} />
+          </div>
+        ))}
+      </GridLayout>
+    )
+  }, [information])
+
   return (
-    <>
-      {information === undefined ? (
-        <Loader />
-      ) : information == null ? (
-        <p className={'text-center text-danger h4'}>{ERROR_OCCURRED}</p>
-      ) : (
-        <Content>
-          <InfoContainer>
-            <ActivityCol>
-              <HeaderCol>
-                <HeaderRow>
-                  <ActivityImg src={getActivityImg(Activity.INFO)}></ActivityImg>
-                  <ActivityType>{getActivityTypeName(Activity.INFO)}</ActivityType>
-                  <ActivityName>{information.name}</ActivityName>
-                </HeaderRow>
-                <FullDivider />
-              </HeaderCol>
-              <div>
-                {information.imageUrls.map((image, idx) => (
-                  <InformationImage src={image} alt={idx} key={idx} />
-                ))}
-              </div>
-              {information.imageUrls.length ? <SmallDivider /> : <></>}
-              <div>
-                <p>{information.description}</p>
-              </div>
-            </ActivityCol>
-          </InfoContainer>
-        </Content>
-      )}
-    </>
+    <Content>
+      <Row className={'m-0 vh-100'}>
+        <Col md={6} className={'py-2'}>
+          <Row className={'m-0 w-100 h-25 pb-2'}>
+            <CustomCard className={'p-0'}>
+              <CardHeader>
+                <h5>Informacje o aktywności</h5>
+              </CardHeader>
+              <Card.Body>{activityInfoCardBody}</Card.Body>
+            </CustomCard>
+          </Row>
+          <Row className={'m-0 w-100 h-75'}>
+            <CustomCard className={'p-0'}>
+              <CardHeader>
+                <h5>Opis</h5>
+              </CardHeader>
+              <Card.Body className={'overflow-auto'} style={{ maxHeight: '70vh' }}>
+                {information === undefined ? (
+                  <Loader />
+                ) : information == null ? (
+                  <p>{ERROR_OCCURRED}</p>
+                ) : (
+                  <p>{information.description}</p>
+                )}
+              </Card.Body>
+            </CustomCard>
+          </Row>
+        </Col>
+        <Col md={6} className={'py-2'}>
+          <CustomCard className={'p-0'} style={{ maxHeight: '98.3vh', overflowY: 'auto' }}>
+            <CardHeader className={'position-sticky top-0'} style={{ zIndex: 2 }}>
+              <h5>Galeria zdjęć</h5>
+            </CardHeader>
+            <Card.Body ref={gridCardRef}>{imagesGridLayout}</Card.Body>
+          </CustomCard>
+        </Col>
+      </Row>
+    </Content>
   )
 }

--- a/frontend/src/components/student/AllActivities/InfoTask/Information.js
+++ b/frontend/src/components/student/AllActivities/InfoTask/Information.js
@@ -66,13 +66,7 @@ export default function Information() {
     }
 
     if (gridCardRef.current?.offsetWidth) {
-      return (
-        <ImagesGallery
-          width={gridCardRef.current.offsetWidth - 32}
-          images={information.imageUrls.concat([...information.imageUrls, ...information.imageUrls])}
-          cols={3}
-        />
-      )
+      return <ImagesGallery width={gridCardRef.current.offsetWidth - 32} images={information.imageUrls} cols={3} />
     }
 
     return <></>

--- a/frontend/src/components/student/AllActivities/InfoTask/InformationStyles.js
+++ b/frontend/src/components/student/AllActivities/InfoTask/InformationStyles.js
@@ -4,3 +4,30 @@ export const InformationImage = styled.img`
   max-width: 90%;
   margin-bottom: 20px;
 `
+
+export const InformationTable = styled.table`
+  width: 100%;
+  border: none !important;
+
+  tr {
+    word-break: break-all;
+  }
+
+  td {
+    color: lightgrey;
+    border: none !important;
+  }
+
+  td:first-child {
+    width: 30%;
+  }
+
+  td:nth-child(odd) {
+    white-space: nowrap;
+    color: var(--font-color);
+  }
+
+  td:nth-child(even) {
+    text-align: right;
+  }
+`


### PR DESCRIPTION
Od nowa zrobiłem widok wytycznych. Dodałem galerię zdjęć ułożoną na dynamicznie dopasowującym gridzie - zdjęcia układają się jeden pod drugim w ładny sposób. Dodatkowo do każdego zdjęcia dodałem panel kontrolny (menu kontekstowe) z opcjami pobierania i pełnego podglądu. W pełnym podglądzie jest opcja przewijania zdjęć, więc jak sie wejdzie do pelnego podglądu to nie trzeba z niego wychodzić żeby przejść do kolejnej grafiki. We wcześniejszej wersji był drag&drop, ale uznałem, że to niepotrzebny bajer psujący wydajność, dlatego wyłączyłem tę funkcję.