### PR TITLE
[SC-245] Błąd w endpoincie podsumowania gry

### DIFF
--- a/api/src/main/java/com/example/api/service/activity/result/SummaryService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/SummaryService.java
@@ -28,10 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
@@ -93,14 +90,18 @@ public class SummaryService {
                 .stream()
                 .map(AverageGrade::getAvgGradesForChapter)
                 .flatMap(Collection::stream)
-                .mapToDouble(AverageGradeForChapter::getAvgGrade);
+                .filter(Objects::nonNull)
+                .map(AverageGradeForChapter::getAvgGrade)
+                .filter(Objects::nonNull)
+                .mapToDouble(d -> d);
     }
 
     public Double getAvgGrade(List<AverageGrade> avgGradesList) {
         if (avgGradesList.isEmpty()) return null;
-        Double grade = flatMapAvgGradesList(avgGradesList)
-                .average().getAsDouble();
-        return GradesCalculator.roundGrade(grade);
+        OptionalDouble grade = flatMapAvgGradesList(avgGradesList)
+                .filter(Objects::nonNull)
+                .average();
+        return grade.isPresent() ? GradesCalculator.roundGrade(grade.getAsDouble()) : null;
     }
 
     public Double getMedianGrade(User professor) {


### PR DESCRIPTION
Brakowało null check'a, przez co wywalało /summary po dodaniu nowego rozdziału bez aktywności. Sprawdziłem jeszcze co zwróci /summary gdy nie będzie żadnych aktywności i rozdziałów:

```
{
  "avgGrade": null,
  "medianGrade": null,
  "bestScoreActivityName": null,
  "worstScoreActivityName": null,
  "assessedActivityCounter": 0,
  "notAssessedActivityCounter": 0,
  "waitingAnswersNumber": 0,
  "avgGradesList": [],
  "avgActivitiesScore": [],
  "notAssessedActivitiesTable": []
}
```