### PR TITLE
[SC-265] Błędne ustawienie wymagań aktywności

### DIFF
--- a/api/src/main/java/com/example/api/config/DatabaseConfig.java
+++ b/api/src/main/java/com/example/api/config/DatabaseConfig.java
@@ -328,26 +328,26 @@ public class DatabaseConfig {
             Requirement requirement6 = new Requirement();
             Requirement requirement7 = new Requirement();
 
-            requirement1.setName("Date from");
             requirement1.setSelected(false);
+            requirement1.setName(MessageManager.DATE_FROM_REQ_NAME);
             requirement1.setType(RequirementType.DATE_FROM);
-            requirement2.setName(MessageManager.DATE_FROM_REQ_NAME);
             requirement2.setSelected(false);
+            requirement2.setName(MessageManager.DATE_TO_REQ_NAME);
             requirement2.setType(RequirementType.DATE_TO);
-            requirement3.setName(MessageManager.DATE_TO_REQ_NAME);
             requirement3.setSelected(false);
+            requirement3.setName(MessageManager.MIN_POINTS_REQ_NAME);
             requirement3.setType(RequirementType.MIN_POINTS);
-            requirement4.setName(MessageManager.MIN_POINTS_REQ_NAME);
             requirement4.setSelected(false);
+            requirement4.setName(MessageManager.GROUPS_REQ_NAME);
             requirement4.setType(RequirementType.GROUPS);
-            requirement5.setName(MessageManager.GROUPS_REQ_NAME);
             requirement5.setSelected(false);
+            requirement5.setName(MessageManager.STUDENTS_REQ_NAME);
             requirement5.setType(RequirementType.STUDENTS);
-            requirement6.setName(MessageManager.GRAPH_TASKS_REQ_NAME);
             requirement6.setSelected(false);
+            requirement6.setName(MessageManager.GRAPH_TASKS_REQ_NAME);
             requirement6.setType(RequirementType.GRAPH_TASKS);
-            requirement7.setName(MessageManager.FILE_TASKS_REQ_NAME);
             requirement7.setSelected(false);
+            requirement7.setName(MessageManager.FILE_TASKS_REQ_NAME);
             requirement7.setType(RequirementType.FILE_TASKS);
 
             requirement1.setDateFrom(System.currentTimeMillis());

--- a/api/src/main/java/com/example/api/service/activity/task/TaskService.java
+++ b/api/src/main/java/com/example/api/service/activity/task/TaskService.java
@@ -239,34 +239,43 @@ public class TaskService {
             Requirement requirement = requirementRepo.findRequirementById(requirementForm.getId());
             mapValidator.validateRequirementIsNotNull(requirement, requirementForm.getId());
             requirement.setSelected(requirementForm.getSelected());
+            String value = requirementForm.getValue();
             switch (requirement.getType()) {
                 case DATE_FROM -> {
-                    Long dateFrom = Long.valueOf(requirementForm.getValue());
+                    Long dateFrom = value.equals("") ? null : Long.valueOf(value);
                     requirement.setDateFrom(dateFrom);
                 }
                 case DATE_TO -> {
-                    Long dateTo = Long.valueOf(requirementForm.getValue());
+                    Long dateTo =  value.equals("") ? null : Long.valueOf(requirementForm.getValue());
                     requirement.setDateTo(dateTo);
                 }
                 case MIN_POINTS -> {
-                    Double minPoints = Double.valueOf(requirementForm.getValue());
+                    Double minPoints =  value.equals("") ? null : Double.valueOf(requirementForm.getValue());
                     requirement.setMinPoints(minPoints);
                 }
                 case GROUPS -> {
+                    if (value.equals("")) {
+                        requirement.setAllowedGroups(new LinkedList<>());
+                        break;
+                    }
                     String[] groupNames = requirementForm.getValue().split(";");
                     List<Group> groups = new LinkedList<>();
-                    for (String grouName: groupNames) {
-                        Group group = groupRepo.findGroupByName(grouName);
+                    for (String groupName: groupNames) {
+                        Group group = groupRepo.findGroupByName(groupName);
                         groupValidator.validateGroupIsNotNullWithMessage(
                                 group,
-                                grouName,
-                                ExceptionMessage.GROUP_NOT_FOUND + grouName
+                                groupName,
+                                ExceptionMessage.GROUP_NOT_FOUND + groupName
                         );
                         groups.add(group);
                     }
                     requirement.setAllowedGroups(groups);
                 }
                 case STUDENTS -> {
+                    if (value.equals("")) {
+                        requirement.setAllowedStudents(new LinkedList<>());
+                        break;
+                    }
                     String[] emails = requirementForm.getValue().split(";");
                     List<User> students = new LinkedList<>();
                     for(String email: emails) {
@@ -281,6 +290,10 @@ public class TaskService {
                     requirement.setAllowedStudents(students);
                 }
                 case GRAPH_TASKS -> {
+                    if (value.equals("")) {
+                        requirement.setFinishedGraphTasks(new LinkedList<>());
+                        break;
+                    }
                     String[] titles = requirementForm.getValue().split(";");
                     List<GraphTask> graphTasks = new LinkedList<>();
                     for (String title: titles) {
@@ -295,6 +308,10 @@ public class TaskService {
                     requirement.setFinishedGraphTasks(graphTasks);
                 }
                 case FILE_TASKS -> {
+                    if (value.equals("")) {
+                        requirement.setFinishedFileTasks(new LinkedList<>());
+                        break;
+                    }
                     List<String> titles = Arrays.asList(requirementForm.getValue().split(";"));
                     List<FileTask> fileTasks = new LinkedList<>();
                     for (String title: titles) {


### PR DESCRIPTION
Dodałem obsługę pustych wymagań (czyli "") przy wysyłaniu przez api/task/requirements/add. Ustawienie "" oznacza, że dane wymaganie będzie miało wartość null (w przypadku wartości liczbowych) lub pustą LinkedListę (dla grup, studentów, zadań). Co do nieprzepuszczania nieprawidłowych pól z selected=false to myśle, że tak powinno być, chyba, że źle to zrozumiałem. Przy debugowaniu natrafiłem na buga na froncie (przynajmniej mi się tak wydaje) 
- https://systematic-chaos.atlassian.net/jira/software/projects/SC/boards/1/backlog?selectedIssue=SC-266

Przy okazji z tymi formularzami chyba jest coś nie tak. Jest tam DateFrom i Data do której aktywność będzie dostępna a nie ma listy studentów przez co przy inputy są źle podpisane. 
<img width="1192" alt="Zrzut ekranu 2022-09-19 o 21 51 03" src="https://user-images.githubusercontent.com/56938330/191104045-f1b97238-f1c3-4e80-814a-857451db8507.png">
Np. to mi przechodzi a mam w minimalnej ilości punktów grupę. Poniżej call dla tego ustawienia.

<img width="834" alt="Zrzut ekranu 2022-09-19 o 21 52 19" src="https://user-images.githubusercontent.com/56938330/191104334-d41f0ecd-1567-49ca-94f4-75cdc72be9ac.png">

