### PR TITLE
[SC-289] Bugi w modalu rozdziału

### DIFF
--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -21,7 +21,7 @@ function App(props) {
         <div className={'d-flex'} style={{ minHeight: '100vh', margin: 0 }}>
           <BrowserRouter>
             <SidebarCol
-              style={{ width: props.sidebar.isExpanded ? 350 : 60 }}
+              style={{ width: props.sidebar.isExpanded ? 400 : 60 }}
               className={window.location.pathname === '/' ? 'd-none' : 'd-md-block d-none'}
             >
               <Sidebar link_titles={student ? UserSidebarTitles : ProfessorSidebarTitles} />

--- a/frontend/src/components/general/ImagesGallery/ImagesGallery.js
+++ b/frontend/src/components/general/ImagesGallery/ImagesGallery.js
@@ -149,7 +149,7 @@ function ImagesGallery(props) {
         <ModalBody className={'d-flex justify-content-center align-items-center'}>
           <FontAwesomeIcon
             icon={faChevronLeft}
-            className={'display-3 me-5'}
+            className={'display-3 me-3'}
             onClick={() => {
               if (!fullPreviewSource.isFirst) {
                 prevImage(fullPreviewSource.id)
@@ -157,10 +157,10 @@ function ImagesGallery(props) {
             }}
             style={{ opacity: fullPreviewSource.isFirst ? 0.5 : 1, cursor: 'pointer' }}
           />
-          <img height={'100%'} src={fullPreviewSource.src} alt={'full-preview'} />
+          <img width={'90%'} height={'90%'} src={fullPreviewSource.src} alt={'full-preview'} />
           <FontAwesomeIcon
             icon={faChevronRight}
-            className={'display-3 ms-5'}
+            className={'display-3 ms-3'}
             onClick={() => {
               if (!fullPreviewSource.isLast) {
                 nextImage(fullPreviewSource.id)

--- a/frontend/src/components/general/ImagesGallery/ImagesGalleryStyle.js
+++ b/frontend/src/components/general/ImagesGallery/ImagesGalleryStyle.js
@@ -17,4 +17,7 @@ export const ControlPanel = styled(Dropdown)`
   .dropdown-toggle::before {
     display: none !important;
   }
+  .dropdown-menu {
+    min-width: auto;
+  }
 `

--- a/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
+++ b/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
@@ -25,6 +25,7 @@ import EditActivityModal from './EditActivityModal'
 import AddActivityModal from './AddActivityModal'
 import { TeacherRoutes } from '../../../routes/PageRoutes'
 import { ChapterModal } from '../GameManagement/ChapterModal/ChapterModal'
+import { successToast } from '../../../utils/toasts'
 
 function ChapterDetails() {
   const { id: chapterId } = useParams()
@@ -39,6 +40,7 @@ function ChapterDetails() {
   const [isAddActivityModalOpen, setIsAddActivityModalOpen] = useState(false)
   const [mapContainerSize, setMapContainerSize] = useState({ x: 0, y: 0 })
   const [shouldLoadEditChapterModal, setShouldLoadEditChapterModal] = useState(false)
+  const [deleteChapterError, setDeleteChapterError] = useState(undefined)
 
   const mapCardBody = useRef()
 
@@ -104,6 +106,16 @@ function ChapterDetails() {
       activityName: activity.title
     })
     setIsDeleteActivityModalOpen(true)
+  }
+
+  const deleteChapter = () => {
+    ChapterService.deleteChapter(chapterId)
+      .then(() => {
+        successToast('Rozdział usunięty pomyślnie.')
+        setDeletionModalOpen(false)
+        navigate(TeacherRoutes.GAME_MANAGEMENT.MAIN)
+      })
+      .catch((error) => setDeleteChapterError(error.response.data.message))
   }
 
   return (
@@ -287,11 +299,15 @@ function ChapterDetails() {
         modalTitle={'Usunięcie rozdziału'}
         modalBody={
           <>
-            Czy na pewno chcesz usunąć rozdział: <br />
-            <strong>{chapterDetails?.name}</strong>?
+            <div>
+              Czy na pewno chcesz usunąć rozdział: <br />
+              <strong>{chapterDetails?.name}</strong>?
+            </div>
+            {deleteChapterError && <p className={'text-danger'}>{deleteChapterError}</p>}
           </>
         }
         chapterId={chapterId}
+        onClick={deleteChapter}
       />
 
       <ChapterModal
@@ -325,6 +341,7 @@ function ChapterDetails() {
             <br />o nazwie: <strong>{chosenActivityData?.activityName}</strong>?
           </>
         }
+        onClick={() => {}}
       />
 
       <AddActivityModal

--- a/frontend/src/components/professor/ChapterDetails/DeletionModal.js
+++ b/frontend/src/components/professor/ChapterDetails/DeletionModal.js
@@ -1,24 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Button, Card, Modal } from 'react-bootstrap'
-import ChapterService from '../../../services/chapter.service'
-import { useNavigate } from 'react-router-dom'
-import { TeacherRoutes } from '../../../routes/PageRoutes'
-import { successToast } from '../../../utils/toasts'
 
 function DeletionModal(props) {
-  const navigate = useNavigate()
-  const [errorMessage, setErrorMessage] = useState('')
-
-  const deleteChapter = () => {
-    ChapterService.deleteChapter(props.chapterId)
-      .then(() => {
-        successToast('Rozdział usunięty pomyślnie.')
-        props.setModalOpen(false)
-        navigate(TeacherRoutes.GAME_MANAGEMENT.MAIN)
-      })
-      .catch((error) => setErrorMessage(error.response.data.message))
-  }
-
   return (
     <Modal show={props.showModal} onHide={() => props.setModalOpen(false)}>
       <Card>
@@ -30,10 +13,9 @@ function DeletionModal(props) {
           <Button className={'me-1'} variant={'secondary'} onClick={() => props.setModalOpen(false)}>
             Anuluj
           </Button>
-          <Button variant={'danger'} onClick={deleteChapter}>
+          <Button variant={'danger'} onClick={props.onClick}>
             Usuń
           </Button>
-          <p className={'text-danger'}>{errorMessage}</p>
         </Card.Footer>
       </Card>
     </Modal>


### PR DESCRIPTION
1. Dla pierwszego obrazka w liście zepsuło się rozwijane menu.
![image](https://user-images.githubusercontent.com/63460537/193461140-14965d53-1f73-4f18-b531-42cf60c26620.png)
2. Zepsuł się widok pełnego podglądu. 
![image](https://user-images.githubusercontent.com/63460537/193461098-4d879905-a1fb-4779-9311-c1cbc4e343a2.png)
3. Pierwsze obrazki w każdym wierszu mają menu w prawo, a nie w lewo.
![image](https://user-images.githubusercontent.com/63460537/193461093-9e2b5d72-2e28-4cfe-9c82-c330093d635a.png)
4. Pod przycisk usuwania aktywności był podpięty endpoint do usuwania rozdziału. 