### PR TITLE
[SC-305] Niepoprawne wyświetlanie postępu studenta

### DIFF
--- a/frontend/src/components/student/BadgesPage/BadgesPage.js
+++ b/frontend/src/components/student/BadgesPage/BadgesPage.js
@@ -47,14 +47,15 @@ function BadgesPage(props) {
         const PERCENTAGE_BAR_WIDTH = 200
         const studentPoints = rankInfo.currentPoints
         const nextRankPoints = rankInfo?.nextRank.minPoints
+        const currentRankPoints = rankInfo.currentRank.minPoints
 
         if (!nextRankPoints) {
           return null
         }
 
-        const getGreenBarWidth = ((studentPoints / nextRankPoints) * PERCENTAGE_BAR_WIDTH).toFixed(0)
-
-        const getPercentageValue = Math.floor((studentPoints * 100) / nextRankPoints)
+        const progressPercentage = (studentPoints - currentRankPoints) / (nextRankPoints - currentRankPoints)
+        const getGreenBarWidth = (progressPercentage * PERCENTAGE_BAR_WIDTH).toFixed(0)
+        const getPercentageValue = Math.floor(progressPercentage * 100)
 
         return (
           <PercentageBar $greenBarWidth={getGreenBarWidth} $grayBarWidth={PERCENTAGE_BAR_WIDTH}>


### PR DESCRIPTION
W widoku z rangami u studenta zauważyłem buga, polegającego na niepoprawnym wyświetlaniu w pasku postępu w obecnej randze. 
Przykład:
* Dane:
  * obecna liczba punktów: 113
  * do następnej rangi potrzeba: 200
  * obecną rangę odblokowano przy: 100
* Wyświetlana wartość paska postępu: 56%

Jest to oczywiście błąd wynikający z tego, że liczymy 113/200. 

Jak powinno działać poprawnie? Dzielić 13/100. Dlaczego ? Bo w obecnej randze zdobyliśmy 13 pkt (113 - 100), a różnica między obecną rangą, a następną to 100 pkt (200 - 100)