### PR TITLE
[SC-310] Bugi w summary endpoint

### DIFF
--- a/api/src/main/java/com/example/api/dto/response/activity/task/result/summary/NotAssessedActivity.java
+++ b/api/src/main/java/com/example/api/dto/response/activity/task/result/summary/NotAssessedActivity.java
@@ -1,6 +1,5 @@
 package com.example.api.dto.response.activity.task.result.summary;
 
-import com.example.api.model.activity.result.TaskResult;
 import com.example.api.model.activity.task.Activity;
 import lombok.Data;
 
@@ -16,9 +15,4 @@ public class NotAssessedActivity {
         this.waitingAnswersNumber = 0;
     }
 
-    public void add(TaskResult taskResult) {
-        if (taskResult.isEvaluated()) {
-            waitingAnswersNumber += 1;
-        }
-    }
 }

--- a/api/src/main/java/com/example/api/service/activity/result/SummaryService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/SummaryService.java
@@ -272,8 +272,12 @@ public class SummaryService {
 
     private NotAssessedActivity toNotAssessedActivity(Activity activity) {
         NotAssessedActivity notAssessedActivity = new NotAssessedActivity(activity);
-        getAllResultsForActivity(activity)
-                .forEach(notAssessedActivity::add);
+        int waitingAnswersNumber = getAllResultsForActivity(activity)
+                .stream()
+                .filter(task -> !task.isEvaluated())
+                .toList()
+                .size();
+        notAssessedActivity.setWaitingAnswersNumber(waitingAnswersNumber);
         return notAssessedActivity;
     }
 

--- a/api/src/main/java/com/example/api/service/activity/task/TaskService.java
+++ b/api/src/main/java/com/example/api/service/activity/task/TaskService.java
@@ -84,7 +84,7 @@ public class TaskService {
         return response;
     }
 
-    public TaskToEvaluateResponse getFirstAnswerToEvaluate(Long id) throws EntityNotFoundException, EntityRequiredAttributeNullException {
+    public TaskToEvaluateResponse getFirstAnswerToEvaluate(Long id) throws EntityNotFoundException {
         log.info("Fetching first activity that is needed to be evaluated for file task with id {}", id);
         FileTask task = fileTaskRepo.findFileTaskById(id);
         activityValidator.validateActivityIsNotNull(task, id);

--- a/api/src/main/java/com/example/api/service/validator/RankValidator.java
+++ b/api/src/main/java/com/example/api/service/validator/RankValidator.java
@@ -37,7 +37,7 @@ public class RankValidator {
     public void validateAddRankForm(AddRankForm form) throws RequestValidationException {
         if (form.getName().length() > 30) {
             log.error("Rank name cannot have more than 30 characters!");
-            throw new RequestValidationException(ExceptionMessage.NAME_TO_LONG);
+            throw new RequestValidationException(ExceptionMessage.RANK_NAME_TOO_LONG);
         }
         List<Rank> ranks = rankRepo.findAll()
                 .stream()
@@ -45,7 +45,7 @@ public class RankValidator {
                 .toList();
         if (ranks.stream().anyMatch(rank -> Objects.equals(rank.getMinPoints(), form.getMinPoints()))) {
             log.error("Two ranks cannot have the same minPoint");
-            throw new RequestValidationException(ExceptionMessage.THE_SAME_MIN_POINTS);
+            throw new RequestValidationException(ExceptionMessage.SAME_RANK_MIN_POINTS);
         }
     }
 }


### PR DESCRIPTION
Teraz /summary powinien zwracać prawidłową:
- listę aktywności do sprawdzenia(notAssessedActivitiesTable)
- liczbę nieocenionych aktywności (notAssessedActivityCounter) 
- liczbę ocenionych aktywności (assessedActivityCounter)
- liczbę odpowiedzi czekających do oceny (waitingAnswersNumber)

Jeśli zauważyliście jakieś inne bugi, których tu nie uwzględniłem to podrzućcie je