### PR TITLE
[SC-325] Refactor wymagań na froncie

### DIFF
--- a/api/src/main/java/com/example/api/controller/activity/task/TaskController.java
+++ b/api/src/main/java/com/example/api/controller/activity/task/TaskController.java
@@ -4,6 +4,7 @@ import com.example.api.dto.request.activity.task.requirement.ActivityRequirement
 import com.example.api.dto.response.activity.task.ActivitiesResponse;
 import com.example.api.dto.response.activity.task.ActivityToEvaluateResponse;
 import com.example.api.dto.response.activity.task.TaskToEvaluateResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.dto.response.map.RequirementResponse;
 import com.example.api.error.exception.*;
 import com.example.api.service.activity.task.TaskService;
@@ -40,7 +41,7 @@ public class TaskController {
     }
 
     @GetMapping("/requirements")
-    ResponseEntity<List<? extends RequirementResponse<?>>> getRequirementsForActivity(@RequestParam Long activityId)
+    ResponseEntity<RequirementResponse> getRequirementsForActivity(@RequestParam Long activityId)
             throws EntityNotFoundException, MissingAttributeException {
         return ResponseEntity.ok().body(taskService.getRequirementsForActivity(activityId));
     }

--- a/api/src/main/java/com/example/api/dto/request/activity/task/requirement/RequirementForm.java
+++ b/api/src/main/java/com/example/api/dto/request/activity/task/requirement/RequirementForm.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class RequirementForm {
+public class  RequirementForm {
     private Long id;
-    private Boolean isSelected;
+    private Boolean selected;
     private String value;
 }

--- a/api/src/main/java/com/example/api/dto/response/map/RequirementDTO.java
+++ b/api/src/main/java/com/example/api/dto/response/map/RequirementDTO.java
@@ -1,0 +1,15 @@
+package com.example.api.dto.response.map;
+
+import com.example.api.model.map.requirement.RequirementValueType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RequirementDTO<T> {
+    private Long id;
+    private String name;
+    private T value;
+    private RequirementValueType type;
+    private Boolean selected;
+}

--- a/api/src/main/java/com/example/api/dto/response/map/RequirementResponse.java
+++ b/api/src/main/java/com/example/api/dto/response/map/RequirementResponse.java
@@ -1,15 +1,13 @@
 package com.example.api.dto.response.map;
 
-import com.example.api.model.map.requirement.RequirementValueType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
-public class RequirementResponse<T> {
-    private Long id;
-    private String name;
-    private T value;
-    private RequirementValueType type;
-    private Boolean selected;
+public class RequirementResponse {
+    private Boolean isBlocked;
+    private List<? extends RequirementDTO<?>> requirements;
 }

--- a/api/src/main/java/com/example/api/model/map/requirement/DateFromRequirement.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/DateFromRequirement.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
 import com.example.api.util.visitor.RequirementValueVisitor;
@@ -35,8 +35,8 @@ public class DateFromRequirement extends Requirement{
     }
 
     @Override
-    public RequirementResponse<Long> getResponse() {
-        return new RequirementResponse<>(
+    public RequirementDTO<Long> getResponse() {
+        return new RequirementDTO<>(
                 getId(),
                 getName(),
                 dateFromMillis,

--- a/api/src/main/java/com/example/api/model/map/requirement/DateToRequirement.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/DateToRequirement.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
 import com.example.api.util.visitor.RequirementValueVisitor;
@@ -40,8 +40,8 @@ public class DateToRequirement extends Requirement {
     }
 
     @Override
-    public RequirementResponse<Long> getResponse() {
-        return new RequirementResponse<>(
+    public RequirementDTO<Long> getResponse() {
+        return new RequirementDTO<>(
                 getId(),
                 getName(),
                 dateToMillis,

--- a/api/src/main/java/com/example/api/model/map/requirement/FileTasksRequirement.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/FileTasksRequirement.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.model.activity.task.FileTask;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
@@ -40,15 +40,15 @@ public class FileTasksRequirement extends Requirement {
     }
 
     @Override
-    public RequirementResponse<List<String>> getResponse() {
+    public RequirementDTO<List<String>> getResponse() {
         List<String> titles = finishedFileTasks.stream()
                 .map(FileTask::getTitle)
                 .toList();
-        return new RequirementResponse<>(
+        return new RequirementDTO<>(
                 getId(),
                 getName(),
                 titles,
-                RequirementValueType.DATE,
+                RequirementValueType.MULTI_SELECT,
                 getSelected()
         );
     }

--- a/api/src/main/java/com/example/api/model/map/requirement/GraphTasksRequirement.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/GraphTasksRequirement.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.model.activity.task.GraphTask;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
@@ -40,15 +40,15 @@ public class GraphTasksRequirement extends Requirement {
     }
 
     @Override
-    public RequirementResponse<List<String>> getResponse() {
+    public RequirementDTO<List<String>> getResponse() {
         List<String> titles = finishedGraphTasks.stream()
                 .map(GraphTask::getTitle)
                 .toList();
-        return new RequirementResponse<>(
+        return new RequirementDTO<>(
                 getId(),
                 getName(),
                 titles,
-                RequirementValueType.DATE,
+                RequirementValueType.MULTI_SELECT,
                 getSelected()
         );
     }

--- a/api/src/main/java/com/example/api/model/map/requirement/GroupsRequirement.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/GroupsRequirement.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.model.group.Group;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
@@ -40,15 +40,15 @@ public class GroupsRequirement extends Requirement {
     }
 
     @Override
-    public RequirementResponse<List<String>> getResponse() {
+    public RequirementDTO<List<String>> getResponse() {
         List<String> groupNames = allowedGroups.stream()
                 .map(Group::getName)
                 .toList();
-        return new RequirementResponse<>(
+        return new RequirementDTO<>(
                 getId(),
                 getName(),
                 groupNames,
-                RequirementValueType.DATE,
+                RequirementValueType.MULTI_SELECT,
                 getSelected()
         );
     }

--- a/api/src/main/java/com/example/api/model/map/requirement/MinPointsRequirement.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/MinPointsRequirement.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
 import com.example.api.util.visitor.RequirementValueVisitor;
@@ -35,12 +35,12 @@ public class MinPointsRequirement extends Requirement {
     }
 
     @Override
-    public RequirementResponse<Double> getResponse() {
-        return new RequirementResponse<>(
+    public RequirementDTO<Double> getResponse() {
+        return new RequirementDTO<>(
                 getId(),
                 getName(),
                 minPoints,
-                RequirementValueType.DATE,
+                RequirementValueType.NUMBER,
                 getSelected()
         );
     }

--- a/api/src/main/java/com/example/api/model/map/requirement/Requirement.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/Requirement.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
 import com.example.api.util.visitor.RequirementValueVisitor;
@@ -30,7 +30,7 @@ public abstract class Requirement {
 
     public abstract boolean isFulfilled(RequirementFulfilledVisitor visitor);
     public abstract void setValue(RequirementValueVisitor visitor, String value) throws RequestValidationException;
-    public abstract RequirementResponse<?> getResponse();
+    public abstract RequirementDTO<?> getResponse();
     public Long getDateToMillis() {
         return null;
     }

--- a/api/src/main/java/com/example/api/model/map/requirement/StudentsRequirements.java
+++ b/api/src/main/java/com/example/api/model/map/requirement/StudentsRequirements.java
@@ -1,6 +1,6 @@
 package com.example.api.model.map.requirement;
 
-import com.example.api.dto.response.map.RequirementResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.error.exception.RequestValidationException;
 import com.example.api.model.user.User;
 import com.example.api.util.visitor.RequirementFulfilledVisitor;
@@ -40,15 +40,15 @@ public class StudentsRequirements  extends Requirement{
     }
 
     @Override
-    public RequirementResponse<List<String>> getResponse() {
+    public RequirementDTO<List<String>> getResponse() {
         List<String> emails = allowedStudents.stream()
                 .map(User::getEmail)
                 .toList();
-        return new RequirementResponse<>(
+        return new RequirementDTO<>(
                 getId(),
                 getName(),
                 emails,
-                RequirementValueType.DATE,
+                RequirementValueType.MULTI_SELECT,
                 getSelected()
         );
     }

--- a/api/src/main/java/com/example/api/service/activity/task/TaskService.java
+++ b/api/src/main/java/com/example/api/service/activity/task/TaskService.java
@@ -6,6 +6,7 @@ import com.example.api.dto.response.activity.task.ActivitiesResponse;
 import com.example.api.dto.response.activity.task.ActivityToEvaluateResponse;
 import com.example.api.dto.response.activity.task.TaskToEvaluateResponse;
 import com.example.api.dto.response.activity.task.util.FileResponse;
+import com.example.api.dto.response.map.RequirementDTO;
 import com.example.api.dto.response.map.RequirementResponse;
 import com.example.api.dto.response.map.task.ActivityType;
 import com.example.api.error.exception.*;
@@ -136,12 +137,13 @@ public class TaskService {
                 .toList();
     }
 
-    public List<? extends RequirementResponse<?>> getRequirementsForActivity(Long id) throws EntityNotFoundException, MissingAttributeException {
+    public RequirementResponse getRequirementsForActivity(Long id) throws EntityNotFoundException, MissingAttributeException {
         Activity activity = getActivity(id);
-        return activity.getRequirements()
+        List<? extends RequirementDTO<?>> requirements = activity.getRequirements()
                 .stream()
                 .map(Requirement::getResponse)
                 .toList();
+        return new RequirementResponse(activity.getIsBlocked(), requirements);
     }
 
 
@@ -156,7 +158,7 @@ public class TaskService {
             Requirement requirement = requirementRepo.findRequirementById(requirementForm.getId());
             mapValidator.validateRequirementIsNotNull(requirement, requirementForm.getId());
 
-            requirement.setSelected(requirementForm.getIsSelected());
+            requirement.setSelected(requirementForm.getSelected());
             requirement.setValue(requirementValueVisitor, requirementForm.getValue());
         }
     }

--- a/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
+++ b/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
@@ -102,9 +102,9 @@ function ChapterDetails(props) {
       })
   }, [])
 
-  const goToChapterDetails = (activityName, activityId, activityType, isActivityBlocked) => {
+  const goToChapterDetails = (activityName, activityId, activityType) => {
     navigate(location.pathname + `/activity/${activityName}`, {
-      state: { activityId: activityId, activityType: activityType, isBlocked: isActivityBlocked }
+      state: { activityId: activityId, activityType: activityType }
     })
   }
 
@@ -281,9 +281,7 @@ function ChapterDetails(props) {
                         >
                           <TableRow
                             $background={props.theme.primary}
-                            onClick={() =>
-                              goToChapterDetails(activity.title, activity.id, activity.type, activity.isActivityBlocked)
-                            }
+                            onClick={() => goToChapterDetails(activity.title, activity.id, activity.type)}
                             style={{ opacity: activity.isActivityBlocked ? 0.4 : 1 }}
                           >
                             <td>

--- a/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
+++ b/frontend/src/components/professor/ChapterDetails/ChapterDetails.js
@@ -102,9 +102,9 @@ function ChapterDetails(props) {
       })
   }, [])
 
-  const goToChapterDetails = (activityName, activityId, activityType) => {
+  const goToChapterDetails = (activityName, activityId, activityType, isActivityBlocked) => {
     navigate(location.pathname + `/activity/${activityName}`, {
-      state: { activityId: activityId, activityType: activityType }
+      state: { activityId: activityId, activityType: activityType, isBlocked: isActivityBlocked }
     })
   }
 
@@ -269,10 +269,10 @@ function ChapterDetails(props) {
                           key={activity.title + index}
                           placement='top'
                           overlay={
-                            !activity.areRequirementsAdded ? (
+                            activity.isActivityBlocked ? (
                               <CustomTooltip style={{ position: 'fixed' }}>
-                                Aktywność nie ma ustawionych wymagań odblokowania. Studenci nie mogą rozwiązywać
-                                aktywności bez ustawionych wymagań.
+                                Aktywność została zablokowana. Studenci nie mogą jej zobaczyć. Żeby była odblokowana
+                                musisz zmienić to w zakładce "Wymagania".
                               </CustomTooltip>
                             ) : (
                               <></>
@@ -281,8 +281,10 @@ function ChapterDetails(props) {
                         >
                           <TableRow
                             $background={props.theme.primary}
-                            onClick={() => goToChapterDetails(activity.title, activity.id, activity.type)}
-                            style={{ opacity: activity.areRequirementsAdded ? 1 : 0.4 }}
+                            onClick={() =>
+                              goToChapterDetails(activity.title, activity.id, activity.type, activity.isActivityBlocked)
+                            }
+                            style={{ opacity: activity.isActivityBlocked ? 0.4 : 1 }}
                           >
                             <td>
                               <img src={getActivityImg(activity.type)} width={32} height={32} alt={'activity img'} />

--- a/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityDetails.js
+++ b/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityDetails.js
@@ -13,7 +13,7 @@ import { isMobileView } from '../../../../utils/mobileHelper'
 
 function ActivityDetails(props) {
   const location = useLocation()
-  const { activityId, activityType } = location.state
+  const { activityId, activityType, isBlocked } = location.state
 
   const [studentsList, setStudentsList] = useState(undefined)
   const [filteredList, setFilteredList] = useState(undefined)
@@ -81,7 +81,7 @@ function ActivityDetails(props) {
           <ActivityStats activityId={activityId} activityType={activityType} />
         </Tab>
         <Tab eventKey={'requirements'} title={'Wymagania'}>
-          <ActivityRequirements activityId={activityId} />
+          <ActivityRequirements activityId={activityId} isBlocked={isBlocked} />
         </Tab>
       </TabsContainer>
       <Modal show={isStudentAnswerModalOpen} onHide={() => setIsStudentAnswerModalOpen(false)} size={'lg'}>

--- a/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityDetails.js
+++ b/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityDetails.js
@@ -13,7 +13,7 @@ import { isMobileView } from '../../../../utils/mobileHelper'
 
 function ActivityDetails(props) {
   const location = useLocation()
-  const { activityId, activityType, isBlocked } = location.state
+  const { activityId, activityType } = location.state
 
   const [studentsList, setStudentsList] = useState(undefined)
   const [filteredList, setFilteredList] = useState(undefined)
@@ -81,7 +81,7 @@ function ActivityDetails(props) {
           <ActivityStats activityId={activityId} activityType={activityType} />
         </Tab>
         <Tab eventKey={'requirements'} title={'Wymagania'}>
-          <ActivityRequirements activityId={activityId} isBlocked={isBlocked} />
+          <ActivityRequirements activityId={activityId} />
         </Tab>
       </TabsContainer>
       <Modal show={isStudentAnswerModalOpen} onHide={() => setIsStudentAnswerModalOpen(false)} size={'lg'}>

--- a/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityRequirements/ActivityRequirements.js
+++ b/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityRequirements/ActivityRequirements.js
@@ -20,13 +20,15 @@ function ActivityRequirements(props) {
   const [multiSelectLists, setMultiSelectLists] = useState([])
   const [onSaveError, setOnSaveError] = useState('')
   const [isSaving, startSaving] = useTransition()
+  const [isActivityBlocked, setIsActivityBlocked] = useState(false)
 
   const blockadeRef = useRef()
 
   useEffect(() => {
     ActivityService.getActivityRequirements(props.activityId)
       .then((response) => {
-        setRequirementsList(response.map((requirement) => ({ ...requirement, answer: null })))
+        setRequirementsList(response.requirements.map((requirement) => ({ ...requirement, answer: null })))
+        setIsActivityBlocked(response.isBlocked)
       })
       .catch(() => {
         setRequirementsList(null)
@@ -179,7 +181,8 @@ function ActivityRequirements(props) {
           <Form.Check
             ref={blockadeRef}
             className={'pt-3'}
-            defaultChecked={props.isBlocked}
+            checked={isActivityBlocked}
+            onChange={(e) => setIsActivityBlocked(e.target.checked)}
             label={'Zablokuj aktywność i ukryj przed studentami'}
           ></Form.Check>
         </Row>

--- a/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityRequirements/ActivityRequirements.js
+++ b/frontend/src/components/professor/GameManagement/ActivityDetails/ActivityRequirements/ActivityRequirements.js
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState, useTransition } from 'react'
-import { Row, Button, Spinner } from 'react-bootstrap'
+import React, { useCallback, useEffect, useRef, useState, useTransition } from 'react'
+import { Row, Button, Spinner, Form } from 'react-bootstrap'
 import { ERROR_OCCURRED, RequirementType } from '../../../../../utils/constants'
 import { CustomTable } from '../../../../student/GameCardPage/gameCardContentsStyle'
 import { CheckBox, Input, Select, Switch } from './activityRequirementsForms'
@@ -20,6 +20,8 @@ function ActivityRequirements(props) {
   const [multiSelectLists, setMultiSelectLists] = useState([])
   const [onSaveError, setOnSaveError] = useState('')
   const [isSaving, startSaving] = useTransition()
+
+  const blockadeRef = useRef()
 
   useEffect(() => {
     ActivityService.getActivityRequirements(props.activityId)
@@ -74,7 +76,11 @@ function ActivityRequirements(props) {
           value: getAnswer(r)
         }
       })
-      ActivityService.setActivityRequirements(props.activityId, requirementsToSend)
+      ActivityService.setActivityRequirements(
+        props.activityId,
+        requirementsToSend,
+        blockadeRef?.current?.checked ?? false
+      )
         .then(() => {
           successToast()
         })
@@ -92,9 +98,11 @@ function ActivityRequirements(props) {
       case RequirementType.SELECT:
         return <Select requirement={requirement} onChangeCallback={setRequirementsList} />
       case RequirementType.DATE:
+        const date = new Date(requirement.answer ?? requirement.value)
+
         return (
           <DatePicker
-            selected={new Date(requirement.answer ?? requirement.value ?? Date.now())}
+            selected={date instanceof Date && !isNaN(date.getTime()) ? date : new Date()}
             onChange={(date) => onInputChange(requirement.id, date, setRequirementsList)}
             showTimeSelect
             timeFormat={'p'}
@@ -168,6 +176,12 @@ function ActivityRequirements(props) {
               )}
             </tbody>
           </CustomTable>
+          <Form.Check
+            ref={blockadeRef}
+            className={'pt-3'}
+            defaultChecked={props.isBlocked}
+            label={'Zablokuj aktywność i ukryj przed studentami'}
+          ></Form.Check>
         </Row>
       </Row>
       {onSaveError && (

--- a/frontend/src/components/student/GameMapPage/Map/ActivityField.js
+++ b/frontend/src/components/student/GameMapPage/Map/ActivityField.js
@@ -25,7 +25,7 @@ function ActivityField(props) {
     if (activity) {
       ActivityService.getActivityRequirements(activity.id)
         .then((response) => {
-          setRequirements(response?.filter((requirement) => requirement.selected))
+          setRequirements(response.requirements?.filter((requirement) => requirement.selected))
         })
         .catch(() => {
           setRequirements(null)

--- a/frontend/src/components/student/GameMapPage/Map/ActivityField.js
+++ b/frontend/src/components/student/GameMapPage/Map/ActivityField.js
@@ -129,7 +129,7 @@ function ActivityField(props) {
           {colClickable && (
             <Button
               style={{ backgroundColor: 'transparent', borderColor: props.theme.warning, color: props.theme.warning }}
-              disabled={!activity?.isFulfilled}
+              disabled={!activity?.isFulfilled && !activity?.isCompleted}
               className={'position-relative start-50 translate-middle-x mt-3'}
               onClick={startActivity}
             >

--- a/frontend/src/services/activity.service.js
+++ b/frontend/src/services/activity.service.js
@@ -54,9 +54,10 @@ class ActivityService {
     })
   }
 
-  setActivityRequirements(activityId, requirements) {
+  setActivityRequirements(activityId, requirements, isBlocked) {
     return axiosApiPost(POST_TASK_REQUIREMENTS, {
       activityId: activityId,
+      isBlocked: isBlocked,
       requirements: requirements
     }).catch((error) => {
       throw error


### PR DESCRIPTION
Zostały wprowadzone zmiany w działaniu wymagań na backu, więc trzeba je uwzględnić na froncie:
1. Dodałem w wymaganiach checkboxa "Zablokuj aktywność i ukryj przed studentami".
2. Wysyłam w `requirements/add` pole `isBlocked`
3. W `ChapterDetails` sprawdzam pole `isActivityBlocked` przy nakładaniu opacity i tooltipa
4. Przeklikałem przez aplikację i wywaliłem niepotrzebne używanie pól isDefault, isFulfilled, areRequirements... - niektóre zniknęły z endpointów, inne działają nieco inaczej
5. Zmieniłem treść tooltipa.
6. U studenta na mapie button ma być disabled jeżeli `isFulfilled === false && isCompleted === false`