### PR TITLE
[SC-329] Problem ze statystykami aktywności dla ankiet

### DIFF
--- a/api/src/main/java/com/example/api/service/activity/result/TaskResultService.java
+++ b/api/src/main/java/com/example/api/service/activity/result/TaskResultService.java
@@ -232,12 +232,18 @@ public class TaskResultService {
         List<? extends TaskResult> results = getActivityResults(activity);
         results.forEach(
                 result -> {
+                    Double points = result.getPointsReceived();
+                    if (activityIsSurvey) {
+                        Integer rate = ((SurveyResult) result).getRate();
+                        if (rate == null) return;
+                        points = Double.valueOf(rate);
+                    }
                     answersNumber.incrementAndGet();
-                    sumPoints.set(sumPoints.get() + result.getPointsReceived());
-                    if (bestScore.get() == null) bestScore.set(result.getPointsReceived());
-                    else bestScore.set(Math.max(bestScore.get(), result.getPointsReceived()));
-                    if (worstScore.get() == null) worstScore.set(result.getPointsReceived());
-                    else worstScore.set(Math.min(worstScore.get(), result.getPointsReceived()));
+                    sumPoints.set(sumPoints.get() + points);
+                    if (bestScore.get() == null) bestScore.set(points);
+                    else bestScore.set(Math.max(bestScore.get(), points));
+                    if (worstScore.get() == null) worstScore.set(points);
+                    else worstScore.set(Math.min(worstScore.get(), points));
 
                     GroupActivityStatisticsCreator creator = avgScoreCreators.get().get(result.getUser().getGroup());
                     if (creator == null) avgScoreCreators.get().put(result.getUser().getGroup(), new GroupActivityStatisticsCreator(activity, result));

--- a/api/src/main/java/com/example/api/service/activity/result/util/ScaleActivityStatisticsCreator.java
+++ b/api/src/main/java/com/example/api/service/activity/result/util/ScaleActivityStatisticsCreator.java
@@ -50,8 +50,8 @@ public class ScaleActivityStatisticsCreator {
     }
 
     public void addSurvey(SurveyResult surveyResult) {
-        if (surveyResult.getPointsReceived() != null) {
-            statistics.get(surveyResult.getPointsReceived()).incrementResults();
+        if (surveyResult.getRate() != null) {
+            statistics.get(Double.valueOf(surveyResult.getRate())).incrementResults();
         }
     }
 


### PR DESCRIPTION
Przy okazji naprawiania statystyk aktywności dla ankiet zmieniłem to co jest dla nich zwracane. Do tej pory dla ankiety brane były pod uwagę uzyskane punkty, ale to nie ma sensu ponieważ za rozwiązanie ankiety każdy student dostaje max punktow. Dlatego teraz najlepszy, najgorszy, średni wynik itd. w przypadku ankiet dotyczą oceny, którą student dał w ankiecie