### PR TITLE
[SC-331] Wyświetlanie przewidywanych ocen studentów

### DIFF
--- a/frontend/src/components/professor/GradeListAndExport/UsersTable.js
+++ b/frontend/src/components/professor/GradeListAndExport/UsersTable.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ExportButton, GradesTable } from './GradeListAndExportStyles'
 import { Form } from 'react-bootstrap'
 import { debounce } from 'lodash/function'
@@ -7,6 +7,7 @@ import GroupService from '../../../services/group.service'
 import { ERROR_OCCURRED } from '../../../utils/constants'
 import { GameCardOptionPick } from '../../general/GameCardStyles'
 import { connect } from 'react-redux'
+import ProfessorService from '../../../services/professor.service'
 
 function UsersTable(props) {
   const [usersList, setUsersList] = useState(undefined)
@@ -15,6 +16,25 @@ function UsersTable(props) {
   const [users, setUsers] = useState([]) // used to filtering
   const [isButtonDisabled, setButtonDisabled] = useState(true)
   const [isModalVisible, setModalVisible] = useState(false)
+  const [gradesList, setGradesList] = useState(null)
+
+  const getStudentGrade = useCallback(
+    (studentId) => {
+      if (!gradesList) {
+        return '-'
+      }
+
+      const studentGrade = gradesList.find((studentGrade) => studentGrade.student.id === studentId)?.grade
+      return studentGrade ? studentGrade.toFixed(1) : '-'
+    },
+    [gradesList]
+  )
+
+  useEffect(() => {
+    ProfessorService.getStudentGrades().then((response) => {
+      setGradesList(response)
+    })
+  }, [])
 
   useEffect(() => {
     if (props.groupId && props.groupName) {
@@ -103,8 +123,7 @@ function UsersTable(props) {
                   <td className={'py-2'}>
                     {user.firstName} {user.lastName}
                   </td>
-                  {/*TODO: we don't have this information*/}
-                  <td className={'py-2'}>3.5</td>
+                  <td className={'py-2'}>{getStudentGrade(user.id)}</td>
                 </tr>
               ))
             ) : (

--- a/frontend/src/services/professor.service.js
+++ b/frontend/src/services/professor.service.js
@@ -8,7 +8,8 @@ import {
   POST_ADDITIONAL_POINTS,
   GET_POINTS_ALL_LIST_PROFESSOR,
   GET_SUMMARY,
-  GET_PROFESSOR_REGISTER_TOKEN
+  GET_PROFESSOR_REGISTER_TOKEN,
+  GET_GRADES
 } from './urls'
 
 class ProfessorService {
@@ -75,6 +76,12 @@ class ProfessorService {
 
   getRegistrationToken() {
     return axiosApiGet(GET_PROFESSOR_REGISTER_TOKEN).catch((error) => {
+      throw error
+    })
+  }
+
+  getStudentGrades() {
+    return axiosApiGet(GET_GRADES).catch((error) => {
       throw error
     })
   }

--- a/frontend/src/services/urls.js
+++ b/frontend/src/services/urls.js
@@ -155,3 +155,6 @@ export const DELETE_RANK = RANK + '/delete'
 const BADGE = BASE_URL + '/badge'
 export const GET_BADGE_ALL = BADGE + '/all'
 export const GET_BADGE_UNLOCKED_ALL = BADGE + '/unlocked/all'
+
+// Grade Controller
+export const GET_GRADES = BASE_URL + '/grades'


### PR DESCRIPTION
Podpięcie endpointa, który oblicza przewidywane oceny dla studentów.
Gdy student nie ma ocen to z backendu przychodzi `null`. W takim przypadku wstawiłem `-`, dlatego że w wyeksportowanym pliku wstawiamy `-` w kolumnie, dla której nie mamy danych.