### PR TITLE
[SC-332] Naprawienie wyświetlania pozostałego czasu do końca otworzonej ekspedycji na froncie

### DIFF
--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
@@ -2,8 +2,6 @@ import { useNavigate } from 'react-router-dom'
 import { Button, Col, Row, Spinner } from 'react-bootstrap'
 import { Activity, ERROR_OCCURRED, getActivityImg, getActivityTypeName } from '../../../../../utils/constants'
 import { useEffect, useMemo, useState } from 'react'
-
-import StudentService from '../../../../../services/student.service'
 import { convertDateToStringInfo } from '../../../../../utils/Api'
 import ExpeditionService from '../../../../../services/expedition.service'
 import { CustomTable } from '../../../GameCardPage/gameCardContentsStyle'
@@ -16,13 +14,11 @@ import { isMobileView } from '../../../../../utils/mobileHelper'
 
 function ActivityContent(props) {
   const isMobileDisplay = isMobileView()
-
   const navigate = useNavigate()
   const activityId = props.activityId
-
+  const startDate = props.activity.requirements.find((el) => el.dateFromMillis).dateFromMillis
+  const endDate = props.activity.requirements.find((el) => el.dateToMillis).dateToMillis
   const [activityScore, setActivityScore] = useState(undefined)
-  const [startDate, setStartDate] = useState(undefined)
-  const [endDate, setEndDate] = useState(undefined)
   const [pointsReceived, setPointsReceived] = useState(undefined)
   const [isFetching, setIsFetching] = useState(false)
 
@@ -33,25 +29,6 @@ function ActivityContent(props) {
       })
       .catch(() => {
         setActivityScore(null)
-      })
-
-    StudentService.getUserGroup()
-      .then((activityGroup) => {
-        const givenTimeData = props.activity.requirement?.accessDates.find((el) =>
-          el.group.find((el) => el.name === activityGroup.name)
-        )
-
-        if (givenTimeData) {
-          setStartDate(new Date(givenTimeData.dateFrom))
-          setEndDate(new Date(givenTimeData.dateTo))
-        } else {
-          setStartDate('')
-          setEndDate('')
-        }
-      })
-      .catch(() => {
-        setStartDate(null)
-        setEndDate(null)
       })
   }, [activityId, props])
 
@@ -88,10 +65,6 @@ function ActivityContent(props) {
   const basicInfoCard = useMemo(() => {
     if (startDate === undefined && endDate === undefined) {
       return <Spinner animation={'border'} />
-    }
-
-    if (startDate == null || endDate == null) {
-      return <p>{ERROR_OCCURRED}</p>
     }
 
     const tableElements = [

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
@@ -30,12 +30,10 @@ function ActivityContent(props) {
       .catch(() => {
         setActivityScore(null)
       })
-    // if (props.activity.requirements) {
     const startDateGiven = props.activity.requirements?.find((el) => el.dateFromMillis)
     setStartDate(startDateGiven?.dateFromMillis ?? null)
     const endDateGiven = props.activity.requirements?.find((el) => el.dateToMillis) ?? null
     setEndDate(endDateGiven?.dateToMillis ?? null)
-    // }
   }, [activityId, props])
 
   useEffect(() => {

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
@@ -16,8 +16,8 @@ function ActivityContent(props) {
   const isMobileDisplay = isMobileView()
   const navigate = useNavigate()
   const activityId = props.activityId
-  const startDate = props.activity.requirements.find((el) => el.dateFromMillis).dateFromMillis
-  const endDate = props.activity.requirements.find((el) => el.dateToMillis).dateToMillis
+  const [startDate, setStartDate] = useState(undefined)
+  const [endDate, setEndDate] = useState(undefined)
   const [activityScore, setActivityScore] = useState(undefined)
   const [pointsReceived, setPointsReceived] = useState(undefined)
   const [isFetching, setIsFetching] = useState(false)
@@ -30,6 +30,12 @@ function ActivityContent(props) {
       .catch(() => {
         setActivityScore(null)
       })
+    // if (props.activity.requirements) {
+    const startDateGiven = props.activity.requirements?.find((el) => el.dateFromMillis)
+    setStartDate(startDateGiven?.dateFromMillis ?? null)
+    const endDateGiven = props.activity.requirements?.find((el) => el.dateToMillis) ?? null
+    setEndDate(endDateGiven?.dateToMillis ?? null)
+    // }
   }, [activityId, props])
 
   useEffect(() => {


### PR DESCRIPTION
Oryginalny kontekst:
https://github.com/ajablonsk1/systematic-chaos/pull/240#discussion_r1006775483

Generalnie chodzi o to że przy testach okazało się, że nie wykorzytujemy nigdzie `startDate/endDate` w `ActivityContent.js` czyli zawsze wyświetlaliśmy "Brak limitu czasowego" i '-' w miejscach dotyczących czasu dostępności aktywonści na ekranie ekspedycji.

Tutaj jest zamienione łapanie na poprawne informacje z requirements.