### PR TITLE
[SC-341] Widoki do resetu hasła

### DIFF
--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -11,6 +11,7 @@ import { ToastContainer } from 'react-toastify'
 import { isStudent } from '../../utils/storageManager'
 import AppRoutes from '../../routes/AppRoutes'
 import { ProfessorSidebarTitles, UserSidebarTitles } from '../../utils/sidebarTitles'
+import { sidebarExcludedPaths } from '../../utils/constants'
 
 function App(props) {
   const student = isStudent(props.user)
@@ -22,14 +23,16 @@ function App(props) {
           <BrowserRouter>
             <SidebarCol
               style={{ width: props.sidebar.isExpanded ? 400 : 60 }}
-              className={window.location.pathname === '/' ? 'd-none' : 'd-md-block d-none'}
+              className={sidebarExcludedPaths.includes(window.location.pathname) ? 'd-none' : 'd-md-block d-none'}
             >
               <Sidebar link_titles={student ? UserSidebarTitles : ProfessorSidebarTitles} />
             </SidebarCol>
             <div className='p-0 w-100'>
               <AppRoutes />
             </div>
-            <SidebarCol className={window.location.pathname === '/' ? 'd-none' : 'd-md-none d-block'}>
+            <SidebarCol
+              className={sidebarExcludedPaths.includes(window.location.pathname) ? 'd-none' : 'd-md-none d-block'}
+            >
               <MobileNavbar link_titles={student ? UserSidebarTitles : ProfessorSidebarTitles} />
             </SidebarCol>
             <AuthVerify />

--- a/frontend/src/components/general/LoginAndRegistrationPage/LoginPage/LoginForm.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/LoginPage/LoginForm.js
@@ -5,6 +5,7 @@ import { FormCol } from '../FormCol'
 import { login } from '../../../../actions/auth'
 import { connect } from 'react-redux'
 import { FIELD_REQUIRED, NOT_LOGGED_IN_ERROR } from '../../../../utils/constants'
+import { GeneralRoutes } from '../../../../routes/PageRoutes'
 
 function LoginForm(props) {
   const { dispatch } = props
@@ -40,12 +41,15 @@ function LoginForm(props) {
         setSubmitting(false)
       }}
     >
-      {({ isSubmitting, values, errors, handleSubmit }) => (
+      {({ isSubmitting, handleSubmit }) => (
         <Form onSubmit={handleSubmit}>
           <Container>
             <Row className='mx-auto'>
               {FormCol('Email', 'email', 'email', 12, { errorColor: props.theme.danger })}
               {FormCol('Hasło', 'password', 'password', 12, { errorColor: props.theme.danger })}
+              <a className={'text-end pt-2'} style={{ color: props.theme.font }} href={GeneralRoutes.PASSWORD_RESET}>
+                Nie pamiętasz hasła ?
+              </a>
             </Row>
             <Row className='mt-4 d-flex justify-content-center'>
               <Col sm={12} className='d-flex justify-content-center mb-2'>

--- a/frontend/src/components/general/LoginAndRegistrationPage/RegistrationPage/validators.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/RegistrationPage/validators.js
@@ -41,8 +41,8 @@ export const validateEmail = (email, accountType) => {
     error = FIELD_REQUIRED
   } else if (
     (!studentEmail.test(email) && !professorEmail.test(email)) ||
-    (studentEmail.test(email) && accountType !== AccountType.STUDENT) ||
-    (professorEmail.test(email) && accountType !== AccountType.PROFESSOR)
+    (studentEmail.test(email) && accountType === AccountType.PROFESSOR) ||
+    (professorEmail.test(email) && accountType === AccountType.STUDENT)
   ) {
     error = INCORRECT_EMAIL
   }

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPassword.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPassword.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import Carousel from '../CharactersCarousel/Carousel'
+import ResetPasswordForm from './ResetPasswordForm'
+import { Col, Container, Row } from 'react-bootstrap'
+import { connect } from 'react-redux'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFire } from '@fortawesome/free-solid-svg-icons'
+import { Logo } from '../AuthStyle'
+
+function ResetPassword(props) {
+  return (
+    <Container fluid className={'p-0'}>
+      <Row className='w-100 h-100 align-items-center m-0'>
+        <Carousel />
+        <Col style={{ backgroundColor: props.theme.primary }} md={6} className={'p-0 vh-100'}>
+          <Logo $logoColor={props.theme.font} className={'p-5'}>
+            <FontAwesomeIcon icon={faFire} />
+            <br />
+            Systematic Chaos
+          </Logo>
+
+          <ResetPasswordForm />
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+function mapStateToProps(state) {
+  const theme = state.theme
+
+  return { theme }
+}
+export default connect(mapStateToProps)(ResetPassword)

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
@@ -104,7 +104,9 @@ function ResetPasswordForm(props) {
 
   return (
     <div>
-      <MultiStepProgressBar $step={step} $accentColor={props.theme.font} />
+      <MultiStepProgressBar $step={step} $accentColor={props.theme.font}>
+        <div /> {/*helper - second circle*/}
+      </MultiStepProgressBar>
       <>{formContents[step]}</>
     </div>
   )

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { connect } from 'react-redux'
 import { Button, FormControl, FormGroup, FormLabel, FormText } from 'react-bootstrap'
 import { useNavigate } from 'react-router-dom'
@@ -15,7 +15,27 @@ function ResetPasswordForm(props) {
   const [emailValue, setEmailValue] = useState('')
   const [error, setError] = useState(undefined)
 
-  const firstStepForm = useMemo(() => {
+  const sendResetMail = () => {
+    // TODO
+  }
+
+  const FormButton = useCallback(
+    ({ text, onClick, color = props.theme.success, width = 100, disabled = false }) => {
+      console.log('test')
+      return (
+        <Button
+          style={{ backgroundColor: color, borderColor: color, width: width }}
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {text}
+        </Button>
+      )
+    },
+    [props.theme.success]
+  )
+
+  const FirstStepForm = useMemo(() => {
     const onCancel = () => {
       navigate(GeneralRoutes.HOME)
     }
@@ -43,25 +63,14 @@ function ResetPasswordForm(props) {
         ) : null}
 
         <div className={'my-4 d-flex justify-content-center gap-2 '}>
-          <Button
-            style={{ backgroundColor: props.theme.danger, borderColor: props.theme.danger, width: 100 }}
-            onClick={onCancel}
-          >
-            Anuluj
-          </Button>
-          <Button
-            style={{ backgroundColor: props.theme.success, borderColor: props.theme.success, width: 100 }}
-            disabled={!emailValue || !!error}
-            onClick={() => setStep(1)}
-          >
-            Dalej
-          </Button>
+          {FormButton({ text: 'Anuluj', onClick: onCancel, color: props.theme.danger })}
+          {FormButton({ text: 'Dalej', onClick: () => setStep(1), disabled: !emailValue || !!error })}
         </div>
       </FormGroup>
     )
-  }, [emailValue, error, navigate, props.theme.danger, props.theme.font, props.theme.success])
+  }, [FormButton, emailValue, error, navigate, props.theme.danger, props.theme.font])
 
-  const secondStepForm = useMemo(() => {
+  const SecondStepForm = useMemo(() => {
     return (
       <>
         <p
@@ -73,34 +82,22 @@ function ResetPasswordForm(props) {
         </p>
 
         <div className={'my-4 d-flex justify-content-center gap-2 '}>
-          <Button
-            style={{ backgroundColor: props.theme.danger, borderColor: props.theme.danger, width: 100 }}
-            onClick={() => setStep(0)}
-          >
-            Wstecz
-          </Button>
-          <Button
-            style={{ backgroundColor: props.theme.secondary, borderColor: props.theme.secondary, width: 200 }}
-            onClick={() => {
-              /*TODO*/
-            }}
-          >
-            Wyślij ponownie email
-          </Button>
-          <Button
-            style={{ backgroundColor: props.theme.success, borderColor: props.theme.success, width: 100 }}
-            onClick={() => setStep(2)}
-          >
-            Dalej
-          </Button>
+          {FormButton({ text: 'Wstecz', onClick: () => setStep(0), color: props.theme.danger })}
+          {FormButton({
+            text: 'Wyślij ponownie email',
+            onClick: sendResetMail,
+            color: props.theme.secondary,
+            width: 200
+          })}
+          {FormButton({ text: 'Dalej', onClick: () => setStep(2) })}
         </div>
       </>
     )
-  }, [props.theme])
+  }, [FormButton, props.theme.danger, props.theme.font, props.theme.secondary])
 
-  const thirdStepForm = useMemo(() => {}, [])
+  const ThirdStepForm = useMemo(() => {}, [])
 
-  const formContents = [firstStepForm, secondStepForm, thirdStepForm]
+  const formContents = [FirstStepForm, SecondStepForm, ThirdStepForm]
 
   return (
     <div>

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
@@ -8,15 +8,11 @@ import { debounce } from 'lodash'
 import { validateEmail } from '../RegistrationPage/validators'
 import { AccountType } from '../../../../utils/userRole'
 
-// TODO: walidacja maila funkcją do walidacji
-// TODO: wycentrowanie logo lub reszty - coś jest krzywo
-// TODO: nierówne rozmiary przycisków
-
 function ResetPasswordForm(props) {
   const navigate = useNavigate()
 
-  const [step, setStep] = useState(1)
-  const [emailValue, setEmailValue] = useState(undefined)
+  const [step, setStep] = useState(0)
+  const [emailValue, setEmailValue] = useState('')
   const [error, setError] = useState(undefined)
 
   const firstStepForm = useMemo(() => {
@@ -35,7 +31,7 @@ function ResetPasswordForm(props) {
         <FormLabel className={'fw-bold'} style={{ color: props.theme.font }}>
           Email
         </FormLabel>
-        <FormControl type={'email'} onChange={onInputChange} />
+        <FormControl type={'email'} onChange={onInputChange} defaultValue={emailValue} />
         <FormText style={{ color: props.theme.font, display: 'block' }}>
           Na podany powyżej adres email zostanie wysłany mail umożliwiający reset hasła.
         </FormText>
@@ -56,7 +52,7 @@ function ResetPasswordForm(props) {
           <Button
             style={{ backgroundColor: props.theme.success, borderColor: props.theme.success, width: 100 }}
             disabled={!emailValue || !!error}
-            onClick={() => setStep(2)}
+            onClick={() => setStep(1)}
           >
             Dalej
           </Button>
@@ -65,12 +61,51 @@ function ResetPasswordForm(props) {
     )
   }, [emailValue, error, navigate, props.theme.danger, props.theme.font, props.theme.success])
 
-  const secondStepForm = useMemo(() => {}, [])
+  const secondStepForm = useMemo(() => {
+    return (
+      <>
+        <p
+          style={{ color: props.theme.font }}
+          className={'text-center position-relative translate-middle-x start-50 w-75'}
+        >
+          Twój kod do resetu hasła zostanie wysłany na podany adres email. Jeżeli nie widzisz maila, sprawdź spam.
+          Jeżeli w przeciągu 5min nie otrzymasz maila z kodem, kliknij przycisk "Wyślij ponownie email"
+        </p>
+
+        <div className={'my-4 d-flex justify-content-center gap-2 '}>
+          <Button
+            style={{ backgroundColor: props.theme.danger, borderColor: props.theme.danger, width: 100 }}
+            onClick={() => setStep(0)}
+          >
+            Wstecz
+          </Button>
+          <Button
+            style={{ backgroundColor: props.theme.secondary, borderColor: props.theme.secondary, width: 200 }}
+            onClick={() => {
+              /*TODO*/
+            }}
+          >
+            Wyślij ponownie email
+          </Button>
+          <Button
+            style={{ backgroundColor: props.theme.success, borderColor: props.theme.success, width: 100 }}
+            onClick={() => setStep(2)}
+          >
+            Dalej
+          </Button>
+        </div>
+      </>
+    )
+  }, [props.theme])
+
+  const thirdStepForm = useMemo(() => {}, [])
+
+  const formContents = [firstStepForm, secondStepForm, thirdStepForm]
 
   return (
     <div>
       <MultiStepProgressBar $step={step} $accentColor={props.theme.font} />
-      {step === 1 ? firstStepForm : step === 2 ? secondStepForm : null}
+      <>{formContents[step]}</>
     </div>
   )
 }

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordForm.js
@@ -1,0 +1,83 @@
+import React, { useMemo, useState } from 'react'
+import { connect } from 'react-redux'
+import { Button, FormControl, FormGroup, FormLabel, FormText } from 'react-bootstrap'
+import { useNavigate } from 'react-router-dom'
+import { GeneralRoutes } from '../../../../routes/PageRoutes'
+import { MultiStepProgressBar } from './ResetPasswordFormStyle'
+import { debounce } from 'lodash'
+import { validateEmail } from '../RegistrationPage/validators'
+import { AccountType } from '../../../../utils/userRole'
+
+// TODO: walidacja maila funkcją do walidacji
+// TODO: wycentrowanie logo lub reszty - coś jest krzywo
+// TODO: nierówne rozmiary przycisków
+
+function ResetPasswordForm(props) {
+  const navigate = useNavigate()
+
+  const [step, setStep] = useState(1)
+  const [emailValue, setEmailValue] = useState(undefined)
+  const [error, setError] = useState(undefined)
+
+  const firstStepForm = useMemo(() => {
+    const onCancel = () => {
+      navigate(GeneralRoutes.HOME)
+    }
+
+    const onInputChange = debounce((emailInput) => {
+      const email = emailInput.target.value
+      setEmailValue(email)
+      setError(validateEmail(email, AccountType.NOT_LOGGED_IN))
+    }, 200)
+
+    return (
+      <FormGroup className={'w-75 position-relative translate-middle-x start-50'}>
+        <FormLabel className={'fw-bold'} style={{ color: props.theme.font }}>
+          Email
+        </FormLabel>
+        <FormControl type={'email'} onChange={onInputChange} />
+        <FormText style={{ color: props.theme.font, display: 'block' }}>
+          Na podany powyżej adres email zostanie wysłany mail umożliwiający reset hasła.
+        </FormText>
+
+        {error ? (
+          <p className={'py-3 text-center'} style={{ color: props.theme.danger }}>
+            {error}
+          </p>
+        ) : null}
+
+        <div className={'my-4 d-flex justify-content-center gap-2 '}>
+          <Button
+            style={{ backgroundColor: props.theme.danger, borderColor: props.theme.danger, width: 100 }}
+            onClick={onCancel}
+          >
+            Anuluj
+          </Button>
+          <Button
+            style={{ backgroundColor: props.theme.success, borderColor: props.theme.success, width: 100 }}
+            disabled={!emailValue || !!error}
+            onClick={() => setStep(2)}
+          >
+            Dalej
+          </Button>
+        </div>
+      </FormGroup>
+    )
+  }, [emailValue, error, navigate, props.theme.danger, props.theme.font, props.theme.success])
+
+  const secondStepForm = useMemo(() => {}, [])
+
+  return (
+    <div>
+      <MultiStepProgressBar $step={step} $accentColor={props.theme.font} />
+      {step === 1 ? firstStepForm : step === 2 ? secondStepForm : null}
+    </div>
+  )
+}
+
+function mapStateToProps(state) {
+  const theme = state.theme
+
+  return { theme }
+}
+export default connect(mapStateToProps)(ResetPasswordForm)

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
@@ -1,0 +1,40 @@
+import styled from 'styled-components'
+
+export const MultiStepProgressBar = styled.div`
+  width: 50px;
+  height: 2px;
+  padding: 20px 0;
+
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+
+  border-top: 2px dashed ${(props) => props.$accentColor};
+
+  &::before,
+  &::after {
+    content: '';
+    display: flex;
+    position: absolute;
+
+    top: -8px;
+
+    width: 14px;
+    height: 14px;
+
+    background-color: ${(props) => props.$accentColor};
+    border-radius: 50%;
+  }
+
+  &::after {
+    left: ${(props) => (props.$step === 2 ? `60px` : '52px')};
+    outline: ${(props) => (props.$step === 2 ? `2px dashed ${props.$accentColor}` : 'none')};
+    outline-offset: 5px;
+  }
+
+  &::before {
+    left: ${(props) => (props.$step === 1 ? `-23px` : '-16px')};
+    outline: ${(props) => (props.$step === 1 ? `2px dashed ${props.$accentColor}` : 'none')};
+    outline-offset: 5px;
+  }
+`

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
@@ -33,8 +33,8 @@ export const MultiStepProgressBar = styled.div`
   }
 
   &::before {
-    left: ${(props) => (props.$step === 1 ? `-23px` : '-16px')};
-    outline: ${(props) => (props.$step === 1 ? `2px dashed ${props.$accentColor}` : 'none')};
+    left: ${(props) => (props.$step === 0 ? `-23px` : '-16px')};
+    outline: ${(props) => (props.$step === 0 ? `2px dashed ${props.$accentColor}` : 'none')};
     outline-offset: 5px;
   }
 `

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
@@ -1,40 +1,46 @@
 import styled from 'styled-components'
 
 export const MultiStepProgressBar = styled.div`
-  width: 50px;
+  width: 124px;
   height: 2px;
   padding: 20px 0;
-
+  border-top: 2px dashed ${(props) => props.$accentColor};
   position: relative;
   left: 50%;
   transform: translateX(-50%);
 
-  border-top: 2px dashed ${(props) => props.$accentColor};
+  & > div {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    background-color: ${(props) => props.$accentColor};
+    border-radius: 50%;
+    left: 50%;
+    transform: translateX(-50%);
+    top: -8px;
+    outline: ${(props) => (props.$step === 1 ? `2px dashed ${props.$accentColor}` : 'none')};
+  }
 
   &::before,
   &::after {
     content: '';
     display: flex;
     position: absolute;
-
     top: -8px;
-
     width: 14px;
     height: 14px;
-
     background-color: ${(props) => props.$accentColor};
     border-radius: 50%;
+    outline-offset: 5px;
   }
 
   &::after {
-    left: ${(props) => (props.$step === 2 ? `60px` : '52px')};
+    right: ${(props) => (props.$step === 2 ? `-23px` : '-16px')};
     outline: ${(props) => (props.$step === 2 ? `2px dashed ${props.$accentColor}` : 'none')};
-    outline-offset: 5px;
   }
 
   &::before {
     left: ${(props) => (props.$step === 0 ? `-23px` : '-16px')};
     outline: ${(props) => (props.$step === 0 ? `2px dashed ${props.$accentColor}` : 'none')};
-    outline-offset: 5px;
   }
 `

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
@@ -19,6 +19,7 @@ export const MultiStepProgressBar = styled.div`
     transform: translateX(-50%);
     top: -8px;
     outline: ${(props) => (props.$step === 1 ? `2px dashed ${props.$accentColor}` : 'none')};
+    outline-offset: 5px;
   }
 
   &::before,

--- a/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/ResetPassword/ResetPasswordFormStyle.js
@@ -4,7 +4,7 @@ export const MultiStepProgressBar = styled.div`
   width: 124px;
   height: 2px;
   padding: 20px 0;
-  border-top: 2px dashed ${(props) => props.$accentColor};
+  //border-top: 2px dashed ${(props) => props.$accentColor};
   position: relative;
   left: 50%;
   transform: translateX(-50%);
@@ -20,6 +20,23 @@ export const MultiStepProgressBar = styled.div`
     top: -8px;
     outline: ${(props) => (props.$step === 1 ? `2px dashed ${props.$accentColor}` : 'none')};
     outline-offset: 5px;
+
+    &::before,
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 7px;
+      width: 47px;
+      height: 2px;
+      border-top: 2px dashed ${(props) => props.$accentColor};
+    }
+    &::before {
+      right: 20px;
+    }
+    &::after {
+      left: 20px;
+    }
   }
 
   &::before,

--- a/frontend/src/routes/AppRoutes.js
+++ b/frontend/src/routes/AppRoutes.js
@@ -17,6 +17,7 @@ import TeacherRankingRoutes from './modules/teacherRoutes/RankingRoutes'
 import CanvasMap from '../components/student/CanvasMapPage/CanvasMap'
 import ProfileRoutes from './modules/studentRoutes/ProfileRoutes'
 import SettingsRoutes from './modules/teacherRoutes/SettingsRoutes'
+import ResetPassword from '../components/general/LoginAndRegistrationPage/ResetPassword/ResetPassword'
 
 export default function AppRoutes() {
   return (
@@ -27,6 +28,16 @@ export default function AppRoutes() {
         element={
           <PageGuard role={Role.NOT_LOGGED_IN}>
             <LoginAndRegistration />
+          </PageGuard>
+        }
+      />
+
+      <Route
+        path='/password-reset'
+        exact
+        element={
+          <PageGuard role={Role.NOT_LOGGED_IN}>
+            <ResetPassword />
           </PageGuard>
         }
       />

--- a/frontend/src/routes/PageRoutes.js
+++ b/frontend/src/routes/PageRoutes.js
@@ -1,5 +1,6 @@
 export const GeneralRoutes = {
   HOME: '/',
+  PASSWORD_RESET: '/password-reset',
   CANVAS: '/canvas' // other case
 }
 

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -44,6 +44,9 @@ export const ANSWER_SAVED = 'Twoja odpowiedź została zapisana'
 export const SANE_MAP_FIELDCOUNT_LIMIT = 10
 export const NUMBER_FROM_RANGE = (rangeMin, rangeMax) => `Wymagana liczba z przedziału [${rangeMin}, ${rangeMax}]`
 
+export const FIELD_WITH_NAME_REQUIRED = (fieldName) => `Pole o nazwie "${fieldName}" jest wymagane.`
+export const ALL_FIELDS_REQUIRED = 'Wszystkie pola są wymagane.'
+
 export const GRAPH_NODE_BASIC_SIZE = 20
 export const GRAPH_NODE_SPECIAL_SIZE = 40
 

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -25,7 +25,7 @@ import warrior16 from '../storage/resources/warrior/15.png'
 import warrior17 from '../storage/resources/warrior/16.png'
 import { HeroType, PlayerType } from './userRole'
 import moment from 'moment'
-import { StudentRoutes } from '../routes/PageRoutes'
+import { GeneralRoutes, StudentRoutes } from '../routes/PageRoutes'
 
 export const FIELD_REQUIRED = 'Pole wymagane.'
 export const NONNEGATIVE_NUMBER = 'Wymagana liczba nieujemna'
@@ -264,3 +264,5 @@ export const BadgeType = {
   GRAPH_TASK_NUMBER: 'GRAPH_TASK_NUMBER',
   TOP_SCORE: 'TOP_SCORE'
 }
+
+export const sidebarExcludedPaths = [GeneralRoutes.HOME, GeneralRoutes.PASSWORD_RESET]

--- a/frontend/src/utils/userRole.js
+++ b/frontend/src/utils/userRole.js
@@ -7,7 +7,8 @@ export const Role = {
 export const AccountType = {
   STUDENT: 'STUDENT',
   PROFESSOR: 'PROFESSOR',
-  ADMIN: 'ADMIN'
+  ADMIN: 'ADMIN',
+  NOT_LOGGED_IN: 'NOT_LOGGED_IN'
 }
 
 export const HeroType = {


### PR DESCRIPTION
Dodane zostały nowe widoki do resetu hasła. Wykorzystano do tego formularz trzyetapowy.

**Flow działania**
1. W widoku logowania dodać opcję “Nie pamiętasz hasła ?”
2. Formularz resetu hasła trzyetapowy:
      * krok 1: input na podanie emaila, na który przyjdzie token potrzebny do zmiany hasła oraz button “Dalej” i "Anuluj"
      * krok 2: wyświetlenie informacji, że token został wysłany na podanego maila i buttony "Wstecz", "Wyślij ponownie", "Dalej"
      * krok 3: trzy inputy - podanie tokenu z maila, nowe hasło, powtórzenie nowego hasła oraz button “Zmień hasło” i "Wstecz"