### PR TITLE
[SC-351] Fix na datę dostępności aktywności w informacjach aktywności

### DIFF
--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
@@ -132,8 +132,7 @@ function ActivityContent(props) {
 
     const tableElements = [
       { name: 'Obecna liczba punktów', value: pointsReceived !== '' ? pointsReceived : 0 },
-      { name: 'Maksymalna liczba punktów do zdobycia', value: props.activity.maxPoints },
-      { name: 'Liczba punktów licząca się jako 100%', value: props.activity.maxPoints100 ?? '-' }
+      { name: 'Maksymalna liczba punktów do zdobycia', value: props.activity.maxPoints }
     ]
 
     return (

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
@@ -30,9 +30,9 @@ function ActivityContent(props) {
       .catch(() => {
         setActivityScore(null)
       })
-    const startDateGiven = props.activity.requirements?.find((el) => el.dateFromMillis)
+    const startDateGiven = props.activity.requirements?.find((el) => el.dateFromMillis && el.selected)
     setStartDate(startDateGiven?.dateFromMillis ?? null)
-    const endDateGiven = props.activity.requirements?.find((el) => el.dateToMillis) ?? null
+    const endDateGiven = props.activity.requirements?.find((el) => el.dateToMillis && el.selected) ?? null
     setEndDate(endDateGiven?.dateToMillis ?? null)
   }, [activityId, props])
 


### PR DESCRIPTION
Traktowaliśmy startDate i endDate przychodzące z serwera jako zawsze obowiązujące jeśli istniały wartości w wymaganiach (“dateToMillis” i “dateFromMillis” miały wartości) ale mogły przyjść z selected: false - teraz to też jest weryfikowane na froncie