### PR TITLE
[SC-349] Funkcjonalność używania umiejętnosci postaci

### DIFF
--- a/api/src/main/java/com/example/api/model/user/hero/Rogue.java
+++ b/api/src/main/java/com/example/api/model/user/hero/Rogue.java
@@ -49,7 +49,7 @@ public class Rogue extends Hero{
     public Boolean canPowerBeUsed(User user, GraphTaskResult result) {
         int level = user.getLevel();
         double points = result.getCurrQuestion().getPoints();
-        if (canSkipQuestion(level, points)) {
+        if (!canSkipQuestion(level, points)) {
             return false;
         }
         return super.canPowerBeUsed(user, result);

--- a/frontend/src/components/general/LoginAndRegistrationPage/RegistrationPage/RegistrationForm.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/RegistrationPage/RegistrationForm.js
@@ -108,17 +108,19 @@ function RegistrationForm(props) {
                             Łotrzyk
                           </option>
                         </Field>
-                        <Info $buttonColor={props.theme.success}>i</Info>
-                        <Description
-                          $background={props.theme.success}
-                          ref={description}
-                          style={{
-                            display: 'none'
-                          }}
-                        >
-                          {HeroDescriptions[character]}
-                          <img src={HeroImg[character]} alt={character} />
-                        </Description>
+                        <Info $buttonColor={props.theme.success}>
+                          <span>i</span>
+                          <Description
+                            $background={props.theme.success}
+                            ref={description}
+                            style={{
+                              display: 'none'
+                            }}
+                          >
+                            {HeroDescriptions[character]}
+                            <img src={HeroImg[character]} alt={character} />
+                          </Description>
+                        </Info>
                       </div>
                     ) : (
                       <Field className='form-control' name={key} type={RegistrationLabelsAndTypes[key][1]} />

--- a/frontend/src/components/general/LoginAndRegistrationPage/RegistrationPage/RegistrationStyle.js
+++ b/frontend/src/components/general/LoginAndRegistrationPage/RegistrationPage/RegistrationStyle.js
@@ -8,8 +8,10 @@ export const Info = styled.div`
   border-color: ${(props) => props.$buttonColor};
   padding: 6px 10px;
   border-radius: 5px;
+  position: relative;
+  height: 36px;
 
-  &:hover + div {
+  &:hover > div {
     display: flex !important;
     flex-direction: column;
   }
@@ -21,8 +23,8 @@ export const Description = styled.div`
   color: white;
   z-index: 2;
   padding: 25px;
-  bottom: 28%;
-  right: 80px;
+  bottom: 36px;
+  right: 0;
   clip-path: polygon(0% 0%, 100% 0%, 100% 75%, 89% 75%, 94% 100%, 50% 75%, 0% 75%);
   width: 500px;
   height: 400px;

--- a/frontend/src/components/general/Tooltip/Tooltip.js
+++ b/frontend/src/components/general/Tooltip/Tooltip.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import ReactTooltip from 'react-tooltip'
+
+function Tooltip(props) {
+  return (
+    <ReactTooltip
+      id={props.id}
+      place={'top'}
+      type={'dark'}
+      effect={'solid'}
+      multiline
+      event='mouseover mouseenter'
+      eventOff='mouseleave mouseout scroll mousewheel blur'
+    />
+  )
+}
+
+export default Tooltip

--- a/frontend/src/components/professor/GameManagement/GameManagement.js
+++ b/frontend/src/components/professor/GameManagement/GameManagement.js
@@ -150,7 +150,7 @@ function GameManagement(props) {
           </Col>
           <Col md={4} className={'py-2'}>
             <ManagementCard
-              header={'Temat gry'}
+              header={'Ustawienia gry'}
               description={'Dopasuj temat fabuły i wygląd całej gry oraz całego systemu.'}
               routePath={TeacherRoutes.GAME_MANAGEMENT.GAME_SETTINGS}
             />

--- a/frontend/src/components/professor/GameManagement/GameSettings/GameSettings.js
+++ b/frontend/src/components/professor/GameManagement/GameSettings/GameSettings.js
@@ -1,15 +1,18 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Content } from '../../../App/AppGeneralStyles'
-import { Button, Col, Form, Row } from 'react-bootstrap'
+import { Button, Col, Form, Modal, ModalBody, ModalHeader, Row } from 'react-bootstrap'
 import gameMap from '../../../../utils/resources/gameMap/map1.png'
 import ColorPicker from './ColorPicker'
 import { useNavigate } from 'react-router-dom'
 import { TeacherRoutes } from '../../../../routes/PageRoutes'
 import { connect } from 'react-redux'
 import { isMobileView } from '../../../../utils/mobileHelper'
+import ManagementCard from '../ManagementCard'
+import SuperPowerEditionModal from './SuperPowerEditionModal'
 
 function GameSettings(props) {
   const navigate = useNavigate()
+  const [isSuperpowerModalVisible, setIsSuperpowerModalVisible] = useState(false)
 
   const colorPickerElements = [
     { header: 'Kolor wiodący', colors: ['#001542', 'white', 'black'] },
@@ -21,46 +24,58 @@ function GameSettings(props) {
   ]
 
   return (
-    <Content>
-      <Row style={{ margin: 0, marginBottom: isMobileView() ? 85 : 0 }}>
-        <Col md={6}>
-          <h3 className={'pt-4'}>Motywy kolorystyczne</h3>
-          <p>Użyte motywy kolorystyczne wpłyną na wygląd aplikacji i wszystkich użytkowników.</p>
-          <Form.Check className={'mb-3'} label={'Wykorzystaj domyślną kolorystykę'} />
-          <Form.Check className={'mb-3'} label={'Zastosuj poniższe zmiany tylko dla moich grup.'} />
-          <div>
-            {colorPickerElements.map((pickerSet, index) => (
-              <ColorPicker key={index} header={pickerSet.header} colors={pickerSet.colors} selectedColorId={0} />
-            ))}
-          </div>
-        </Col>
-        <Col md={6}>
-          <Row style={{ height: '95%', alignContent: 'flex-start' }} className={'d-flex'}>
-            <h3 className={'pt-4'}>Rozgrywka</h3>
-            <p>Zmień wygląd mapy gry.</p>
-            <div>
-              <h5>Wykorzystywana mapa</h5>
-              <img src={gameMap} alt={'actual-game-map'} width={'100%'} />
+    <>
+      <Content>
+        <Row style={{ margin: 0, marginBottom: isMobileView() ? 85 : 0 }}>
+          <Col md={6}>
+            <Row className={'m-0'}>
+              <h3 className={'pt-4'}>Motywy kolorystyczne</h3>
+              <p>Użyte motywy kolorystyczne wpłyną na wygląd aplikacji i wszystkich użytkowników.</p>
+              <Form.Check className={'mb-3'} label={'Wykorzystaj domyślną kolorystykę'} />
+              <Form.Check className={'mb-3'} label={'Zastosuj poniższe zmiany tylko dla moich grup.'} />
+              <div>
+                {colorPickerElements.map((pickerSet, index) => (
+                  <ColorPicker key={index} header={pickerSet.header} colors={pickerSet.colors} selectedColorId={0} />
+                ))}
+              </div>
+            </Row>
+            <Row className={'m-0 text-center'}>
+              <ManagementCard
+                header={'Umiejętności postaci'}
+                description={'Zmiana ustawienia umiejętności postaci .'}
+                callback={() => setIsSuperpowerModalVisible(true)}
+              />
+            </Row>
+          </Col>
+          <Col md={6}>
+            <Row style={{ height: '95%', alignContent: 'flex-start' }} className={'d-flex'}>
+              <h3 className={'pt-4'}>Rozgrywka</h3>
+              <p>Zmień wygląd mapy gry.</p>
+              <div>
+                <h5>Wykorzystywana mapa</h5>
+                <img src={gameMap} alt={'actual-game-map'} width={'100%'} />
+              </div>
+              <div className={'pt-3'} style={{ cursor: 'pointer' }}>
+                <h5>Zaimportuj nową mapę</h5>
+                <input type={'file'} accept={'image/png, image/jpeg'} />
+              </div>
+            </Row>
+            <div className={'gap-2 d-flex justify-content-end'}>
+              <Button
+                style={{ backgroundColor: props.theme.warning, borderColor: props.theme.warning }}
+                onClick={() => navigate(TeacherRoutes.GAME_MANAGEMENT.MAIN)}
+              >
+                Wstecz
+              </Button>
+              <Button style={{ backgroundColor: props.theme.success, borderColor: props.theme.success }}>
+                Zapisz zmiany
+              </Button>
             </div>
-            <div className={'pt-3'} style={{ cursor: 'pointer' }}>
-              <h5>Zaimportuj nową mapę</h5>
-              <input type={'file'} accept={'image/png, image/jpeg'} />
-            </div>
-          </Row>
-          <div className={'gap-2 d-flex justify-content-end'}>
-            <Button
-              style={{ backgroundColor: props.theme.warning, borderColor: props.theme.warning }}
-              onClick={() => navigate(TeacherRoutes.GAME_MANAGEMENT.MAIN)}
-            >
-              Wstecz
-            </Button>
-            <Button style={{ backgroundColor: props.theme.success, borderColor: props.theme.success }}>
-              Zapisz zmiany
-            </Button>
-          </div>
-        </Col>
-      </Row>
-    </Content>
+          </Col>
+        </Row>
+      </Content>
+      <SuperPowerEditionModal isModalVisible={isSuperpowerModalVisible} setModalVisible={setIsSuperpowerModalVisible} />
+    </>
   )
 }
 

--- a/frontend/src/components/professor/GameManagement/GameSettings/GameSettings.js
+++ b/frontend/src/components/professor/GameManagement/GameSettings/GameSettings.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Content } from '../../../App/AppGeneralStyles'
-import { Button, Col, Form, Modal, ModalBody, ModalHeader, Row } from 'react-bootstrap'
+import { Button, Col, Form, Row } from 'react-bootstrap'
 import gameMap from '../../../../utils/resources/gameMap/map1.png'
 import ColorPicker from './ColorPicker'
 import { useNavigate } from 'react-router-dom'

--- a/frontend/src/components/professor/GameManagement/GameSettings/SuperPowerEditionModal.js
+++ b/frontend/src/components/professor/GameManagement/GameSettings/SuperPowerEditionModal.js
@@ -1,0 +1,138 @@
+import React, { useCallback, useRef, useState, useTransition } from 'react'
+import {
+  Button,
+  Form,
+  FormControl,
+  FormLabel,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Spinner
+} from 'react-bootstrap'
+import { connect } from 'react-redux'
+import { HeroType } from '../../../../utils/userRole'
+import { coolDownDescription, ERROR_OCCURRED, getHeroName, getSpecifyDescription } from '../../../../utils/constants'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons'
+import Tooltip from '../../../general/Tooltip/Tooltip'
+import ProfessorService from '../../../../services/professor.service'
+import { successToast } from '../../../../utils/toasts'
+
+function SuperPowerEditionModal(props) {
+  const heroTypes = Object.values(HeroType)
+
+  const [selectedHeroType, setSelectedHeroType] = useState(heroTypes[0])
+  const [errorMessage, setErrorMessage] = useState(undefined)
+  const [isEditionFetching, startEditionProcess] = useTransition()
+
+  const baseValueRef = useRef()
+  const coolDownRef = useRef()
+
+  const editSuperPower = () => {
+    startEditionProcess(() => {
+      const baseValue = +baseValueRef.current?.value
+      let coolDownValue = +coolDownRef.current?.value
+
+      if (!baseValue) {
+        setErrorMessage('Wartość bazowa musi być liczbą.')
+      } else if (!coolDownValue && (selectedHeroType === HeroType.WARRIOR || selectedHeroType === HeroType.WIZARD)) {
+        setErrorMessage('Wartość czasu ładowania musi być liczbą.')
+      } else {
+        setErrorMessage(undefined)
+
+        if (selectedHeroType === HeroType.PRIEST) {
+          coolDownValue = coolDownValue * 60 * 1000 // min -> ms
+        }
+
+        ProfessorService.editHeroSuperPower(selectedHeroType, baseValue, coolDownValue)
+          .then(() => {
+            props.setModalVisible(false)
+            successToast('Umiejętność bohatera została zmieniona poprawnie.')
+          })
+          .catch((error) => {
+            setErrorMessage(error.response?.data?.message ?? ERROR_OCCURRED)
+          })
+      }
+    })
+  }
+
+  const infoIcon = useCallback(
+    (dataFor) => {
+      const dataTip =
+        dataFor === 'coolDownInfo' ? coolDownDescription(selectedHeroType) : getSpecifyDescription(selectedHeroType)
+
+      return (
+        <>
+          <FontAwesomeIcon className={'ms-2'} icon={faCircleInfo} data-for={dataFor} data-tip={dataTip} />
+          <Tooltip id={dataFor} />
+        </>
+      )
+    },
+    [selectedHeroType]
+  )
+
+  return (
+    <Modal show={props.isModalVisible} onHide={() => props.setModalVisible(false)} size={'lg'}>
+      <ModalHeader>
+        <h5>Edycja umiejętności postaci.</h5>
+      </ModalHeader>
+      <ModalBody>
+        <div>
+          <FormLabel className={'fw-bold'}>Rodzaj postaci</FormLabel>
+          <Form.Select onChange={(e) => setSelectedHeroType(e.target.value)}>
+            {heroTypes.map((heroType, index) => (
+              <option value={heroType} name={heroType} key={index}>
+                {getHeroName(heroType)}
+              </option>
+            ))}
+          </Form.Select>
+        </div>
+
+        <div className={'mt-4'}>
+          <FormLabel className={'fw-bold'}>
+            <span>Wartość bazowa</span>
+            {infoIcon('baseValueInfo')}
+          </FormLabel>
+          <FormControl type={'number'} ref={baseValueRef} />
+        </div>
+
+        {selectedHeroType === HeroType.WIZARD || selectedHeroType === HeroType.WARRIOR ? (
+          <div className={'mt-4'}>
+            <FormLabel className={'fw-bold'}>
+              <span>Czas ładowania</span>
+              {infoIcon('coolDownInfo')}
+            </FormLabel>
+            <FormControl type={'number'} ref={coolDownRef} />
+          </div>
+        ) : null}
+      </ModalBody>
+      <ModalFooter>
+        <div className={'gap-2 d-flex w-100 justify-content-center'}>
+          <Button
+            style={{ backgroundColor: props.theme.danger, borderColor: props.theme.danger }}
+            onClick={() => props.setModalVisible(false)}
+          >
+            Anuluj
+          </Button>
+          <Button
+            style={{ backgroundColor: props.theme.success, borderColor: props.theme.success }}
+            onClick={editSuperPower}
+            disabled={isEditionFetching}
+          >
+            {isEditionFetching ? <Spinner animation={'border'} /> : <span>Zapisz</span>}
+          </Button>
+        </div>
+
+        {!!errorMessage ? <p className={'text-danger w-100 text-center'}>{errorMessage}</p> : null}
+      </ModalFooter>
+    </Modal>
+  )
+}
+
+function mapStateToProps(state) {
+  const theme = state.theme
+
+  return { theme }
+}
+export default connect(mapStateToProps)(SuperPowerEditionModal)

--- a/frontend/src/components/professor/GameManagement/ManagementCard.js
+++ b/frontend/src/components/professor/GameManagement/ManagementCard.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 function ManagementCard(props) {
   return (
     <GameCardOptionPick $background={props.theme.secondary} $fontColor={props.theme.font}>
-      <h5 className={'pt-2'}>{props.header}</h5>
+      <h5 className={'px-2 pt-2'}>{props.header}</h5>
       <p className={'px-2'}>{props.description}</p>
       <GameButton
         text={'Przejdź'}

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ActivityInfo/ActivityContent.js
@@ -55,7 +55,6 @@ function ActivityContent(props) {
     navigate(StudentRoutes.GAME_MAP.GRAPH_TASK.EXPEDITION_WRAPPER, {
       state: {
         activityId: activityId,
-        alreadyStarted: activityScore !== -1,
         maxPoints: props.activity.maxPoints
       }
     })

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionSummary/ExpeditionSummary.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionSummary/ExpeditionSummary.js
@@ -67,6 +67,7 @@ function ExpeditionSummary(props) {
   }, [expeditionId, navigate, activityScore])
 
   const finishExpeditionAndGoHome = () => {
+    localStorage.removeItem('questionPoints')
     navigate(StudentRoutes.GAME_MAP.MAIN)
   }
 

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionSummary/ExpeditionSummary.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionSummary/ExpeditionSummary.js
@@ -46,12 +46,14 @@ function ExpeditionSummary(props) {
       //StudentService.getActivityScore()...
       const promise2 = ExpeditionService.getExpeditionAllPoints(activityScore)
         .then((response) => {
-          setScoredPoints(response !== '' ? response : 0)
+          setScoredPoints(!!response ? response?.toFixed(2) : 0)
         })
         .catch(() => setScoredPoints(0))
 
       const promise3 = ExpeditionService.getExpeditionPointsClosed(activityScore)
-        .then((response) => setClosedQuestionPoints(response ?? 0))
+        .then((response) => {
+          setClosedQuestionPoints(response ? response?.toFixed(2) : 0)
+        })
         .catch(() => setClosedQuestionPoints(0))
 
       const promise4 = ExpeditionService.getExpeditionPointsMaxClosed(activityScore)

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionSummary/ExpeditionSummary.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionSummary/ExpeditionSummary.js
@@ -68,6 +68,7 @@ function ExpeditionSummary(props) {
 
   const finishExpeditionAndGoHome = () => {
     localStorage.removeItem('questionPoints')
+    localStorage.removeItem('questionType')
     navigate(StudentRoutes.GAME_MAP.MAIN)
   }
 

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionWrapper/ExpeditionWrapper.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/ExpeditionWrapper/ExpeditionWrapper.js
@@ -111,6 +111,8 @@ export function ExpeditionWrapper() {
       maxPoints={maxPoints}
       questionsPath={expeditionState.currentPath}
       actualQuestionId={expeditionState.questionDetails?.questionId}
+      questions={expeditionState.questions}
+      status={expeditionState.status}
     >
       {wrapperContent}
     </InfoContainer>

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/GraphPreview.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/GraphPreview.js
@@ -7,6 +7,7 @@ import ExpeditionService from '../../../../../services/expedition.service'
 import { getGraphElements, getNodeColor } from '../../../../general/Graph/graphHelper'
 import { GRAPH_NODE_BASIC_SIZE, GRAPH_NODE_SPECIAL_SIZE } from '../../../../../utils/constants'
 import { isMobileView } from '../../../../../utils/mobileHelper'
+import { connect } from 'react-redux'
 
 const CLOSE_PREVIEW_CONTAINER_SIZE = 0
 const OPEN_PREVIEW_CONTAINER_SIZE = isMobileView() ? '95vw' : '40%'
@@ -53,7 +54,7 @@ function GraphPreview(props) {
 
   return (
     <>
-      <GraphTrigger onClick={() => setIsPreviewOpen(!isPreviewOpen)}>
+      <GraphTrigger $color={props.theme.success} onClick={() => setIsPreviewOpen(!isPreviewOpen)}>
         <FontAwesomeIcon icon={faDiagramProject} />
       </GraphTrigger>
       <GraphContainer style={{ width: size, height: size }}>
@@ -63,4 +64,9 @@ function GraphPreview(props) {
   )
 }
 
-export default GraphPreview
+function mapStateToProps(state) {
+  const theme = state.theme
+
+  return { theme }
+}
+export default connect(mapStateToProps)(GraphPreview)

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainer.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainer.js
@@ -27,17 +27,23 @@ export default function InfoContainer(props) {
   const [timer, setTimer] = useState('')
   const [timerInterval, setTimerInterval] = useState(null)
 
+  const setIntervalForTimer = () => {
+    setTimerInterval(
+      setInterval(function () {
+        setRemainingTime((prevState) => prevState - 1)
+      }, 1000)
+    )
+  }
+
   useEffect(() => {
     const timeInSeconds = timeToSolveMillis / 1000
     setRemainingTime(timeInSeconds)
     if (timerInterval == null) {
-      setTimerInterval(
-        setInterval(function () {
-          setRemainingTime((prevState) => prevState - 1)
-        }, 1000)
-      )
+      setIntervalForTimer()
     }
-  }, [timeToSolveMillis, timerInterval])
+
+    // eslint-disable-next-line
+  }, [timeToSolveMillis])
 
   // complete the expedition and record user responses if the expedition has not been completed
   // before the timer runs out
@@ -49,6 +55,12 @@ export default function InfoContainer(props) {
       setTimer(getTimer(remainingTime))
     }
   }, [activityId, remainingTime, timerInterval, endAction])
+
+  const changeRemainingTime = (updatedRemainingTime) => {
+    clearInterval(timerInterval)
+    setRemainingTime(updatedRemainingTime)
+    setIntervalForTimer()
+  }
 
   const percentageBar = useMemo(() => {
     const PERCENTAGE_BAR_WIDTH = 300
@@ -77,7 +89,7 @@ export default function InfoContainer(props) {
         actualQuestionId={props.actualQuestionId}
       />
       <SuperPower
-        setRemainingTime={setRemainingTime}
+        setRemainingTime={changeRemainingTime}
         activityId={activityId}
         questions={props.questions}
         status={props.status}

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainer.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainer.js
@@ -4,6 +4,7 @@ import { TimerContainer } from './InfoContainerStyle'
 import GraphPreview from './GraphPreview'
 import { PercentageBar } from '../../../BadgesPage/BadgesStyle'
 import { isMobileView } from '../../../../../utils/mobileHelper'
+import SuperPower from '../SuperPower/SuperPower'
 
 const mobileViewStyle = {
   right: '50%',
@@ -74,6 +75,12 @@ export default function InfoContainer(props) {
         activityId={props.activityId}
         currentQuestionsPath={props.questionsPath}
         actualQuestionId={props.actualQuestionId}
+      />
+      <SuperPower
+        setRemainingTime={setRemainingTime}
+        activityId={activityId}
+        questions={props.questions}
+        status={props.status}
       />
       {React.cloneElement(props.children, {
         remainingTime: remainingTime

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainer.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainer.js
@@ -74,7 +74,9 @@ export default function InfoContainer(props) {
         $height={PERCENTAGE_BAR_HEIGHT}
         style={isMobileView() ? mobileViewStyle : desktopViewStyle}
       >
-        <strong className={'d-flex justify-content-center'}>{`${props.actualPoints}/${props.maxPoints}`}</strong>
+        <strong className={'d-flex justify-content-center'}>{`${props.actualPoints?.toFixed(2)}/${
+          props.maxPoints
+        }`}</strong>
       </PercentageBar>
     )
   }, [props.actualPoints, props.maxPoints])

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainerStyle.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainerStyle.js
@@ -12,7 +12,7 @@ export const GraphTrigger = styled.div`
   right: 10px;
   bottom: 10px;
   border-radius: 50%;
-  background-color: white;
+  background-color: ${(props) => props.$color};
   z-index: 3;
   display: flex;
   justify-content: center;
@@ -24,11 +24,11 @@ export const GraphTrigger = styled.div`
 
   & svg {
     transition: all 0.2s linear;
+    color: white;
   }
 
   &:hover svg {
     transform: scale(1.5);
-    color: darkblue;
   }
 
   @media (max-width: 575px) {

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainerStyle.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/InfoContainer/InfoContainerStyle.js
@@ -14,10 +14,22 @@ export const GraphTrigger = styled.div`
   border-radius: 50%;
   background-color: white;
   z-index: 3;
-  cursor: pointer;
   display: flex;
   justify-content: center;
   align-items: center;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  & svg {
+    transition: all 0.2s linear;
+  }
+
+  &:hover svg {
+    transform: scale(1.5);
+    color: darkblue;
+  }
 
   @media (max-width: 575px) {
     bottom: 85px;

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/QuestionSelectionDoor/QuestionSelectionDoor.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/QuestionSelectionDoor/QuestionSelectionDoor.js
@@ -5,16 +5,28 @@ import ExpeditionService from '../../../../../services/expedition.service'
 import { ERROR_OCCURRED, EXPEDITION_STATUS } from '../../../../../utils/constants'
 import { connect } from 'react-redux'
 
-function generateDoor(question, noDoors, onDoorClick, buttonColor, questionType) {
+const getQuestionDetails = (questionId, questionType, questionPoints) => {
+  if (questionPoints && questionId === questionPoints.id) {
+    return questionPoints.value + 'pkt'
+  }
+
+  if (questionType && questionId === questionType.id) {
+    return questionType.value
+  }
+
+  return null
+}
+
+function generateDoor(question, noDoors, onDoorClick, buttonColor, questionPoints, questionType) {
+  const questionDetails = getQuestionDetails(question.id, questionType, questionPoints)
+
   return (
     <DoorColumn key={question.id + Date.now()} xl={12 / noDoors} md={12}>
       <Row className='mx-auto'>
         <h3 className={'text-center'}>{question.difficulty?.toUpperCase()}</h3>
-        {questionType?.id === question.id ? (
-          <h5 className={'m-0 p-0 text-center'}>{questionType.type} pkt</h5>
-        ) : (
-          <p style={{ margin: '12px 0' }} />
-        )}
+        <h5 className={'p-0 text-center'} style={{ margin: questionDetails ? '0' : '12px 0' }}>
+          {questionDetails}
+        </h5>
       </Row>
 
       <Row>
@@ -39,7 +51,8 @@ function generateDoor(question, noDoors, onDoorClick, buttonColor, questionType)
 
 function QuestionSelectionDoor(props) {
   const { activityId: expeditionId, questions, reloadInfo } = props
-  const questionType = JSON.parse(localStorage.getItem('questionPoints'))
+  const questionPoints = JSON.parse(localStorage.getItem('questionPoints'))
+  const questionType = JSON.parse(localStorage.getItem('questionType'))
 
   const onDoorClick = (questionId) => {
     // change state, reloadInfo
@@ -60,7 +73,7 @@ function QuestionSelectionDoor(props) {
       ) : (
         <Row className='m-0'>
           {questions.map((question) =>
-            generateDoor(question, questions.length, onDoorClick, props.theme.success, questionType)
+            generateDoor(question, questions.length, onDoorClick, props.theme.success, questionPoints, questionType)
           )}
         </Row>
       )}

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/QuestionSelectionDoor/QuestionSelectionDoor.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/QuestionSelectionDoor/QuestionSelectionDoor.js
@@ -5,11 +5,16 @@ import ExpeditionService from '../../../../../services/expedition.service'
 import { ERROR_OCCURRED, EXPEDITION_STATUS } from '../../../../../utils/constants'
 import { connect } from 'react-redux'
 
-function generateDoor(question, noDoors, onDoorClick, buttonColor) {
+function generateDoor(question, noDoors, onDoorClick, buttonColor, questionType) {
   return (
     <DoorColumn key={question.id + Date.now()} xl={12 / noDoors} md={12}>
       <Row className='mx-auto'>
-        <h3>{question.difficulty?.toUpperCase()}</h3>
+        <h3 className={'text-center'}>{question.difficulty?.toUpperCase()}</h3>
+        {questionType?.id === question.id ? (
+          <h5 className={'m-0 p-0 text-center'}>{questionType.type} pkt</h5>
+        ) : (
+          <p style={{ margin: '12px 0' }} />
+        )}
       </Row>
 
       <Row>
@@ -34,6 +39,7 @@ function generateDoor(question, noDoors, onDoorClick, buttonColor) {
 
 function QuestionSelectionDoor(props) {
   const { activityId: expeditionId, questions, reloadInfo } = props
+  const questionType = JSON.parse(localStorage.getItem('questionPoints'))
 
   const onDoorClick = (questionId) => {
     // change state, reloadInfo
@@ -53,7 +59,9 @@ function QuestionSelectionDoor(props) {
         </p>
       ) : (
         <Row className='m-0'>
-          {questions.map((question) => generateDoor(question, questions.length, onDoorClick, props.theme.success))}
+          {questions.map((question) =>
+            generateDoor(question, questions.length, onDoorClick, props.theme.success, questionType)
+          )}
         </Row>
       )}
     </Content>

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/PriestSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/PriestSuperPower.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react'
+import SuperPowerTrigger from '../SuperPowerTrigger'
+
+function PriestSuperPower(props) {
+  const [superPowerCanBeUsed, setSuperPowerCanBeUsed] = useState(undefined)
+  const [superPowerInfo, setSuperPowerInfo] = useState(undefined)
+
+  useEffect(() => {
+    props
+      .useCheck()
+      .then((response) => {
+        setSuperPowerCanBeUsed(response)
+      })
+      .catch(() => {
+        setSuperPowerCanBeUsed(null)
+      })
+  }, [props, superPowerInfo])
+
+  useEffect(() => {
+    if (superPowerInfo?.value) {
+      props.setRemainingTime(+superPowerInfo.value / 1000) // ms -> s
+    }
+  }, [props, superPowerInfo])
+
+  const startUsingSuperPower = () => {
+    if (!superPowerCanBeUsed?.canBeUsed) {
+      return
+    }
+
+    props
+      .usePower()
+      .then((response) => {
+        setSuperPowerInfo(response)
+      })
+      .catch(() => {
+        setSuperPowerInfo(null)
+      })
+  }
+
+  return <SuperPowerTrigger superPowerCanBeUsed={superPowerCanBeUsed} startSuperPower={startUsingSuperPower} />
+}
+
+export default PriestSuperPower

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/PriestSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/PriestSuperPower.js
@@ -1,22 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import SuperPowerTrigger from '../SuperPowerTrigger'
+import { useSuperPowerCheck } from '../../../../../../hooks/useSuperPowerCheck'
 
 function PriestSuperPower(props) {
-  const [superPowerCanBeUsed, setSuperPowerCanBeUsed] = useState(undefined)
   const [superPowerInfo, setSuperPowerInfo] = useState(undefined)
 
-  useEffect(() => {
-    props
-      .useCheck()
-      .then((response) => {
-        setSuperPowerCanBeUsed(response)
-      })
-      .catch(() => {
-        setSuperPowerCanBeUsed(null)
-      })
-
-    // eslint-disable-next-line
-  }, [superPowerInfo])
+  const superPowerCanBeUsed = useSuperPowerCheck(props.useCheck, superPowerInfo)
 
   useEffect(() => {
     if (superPowerInfo?.value) {

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/PriestSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/PriestSuperPower.js
@@ -14,13 +14,16 @@ function PriestSuperPower(props) {
       .catch(() => {
         setSuperPowerCanBeUsed(null)
       })
-  }, [props, superPowerInfo])
+
+    // eslint-disable-next-line
+  }, [superPowerInfo])
 
   useEffect(() => {
     if (superPowerInfo?.value) {
       props.setRemainingTime(+superPowerInfo.value / 1000) // ms -> s
     }
-  }, [props, superPowerInfo])
+    //eslint-disable-next-line
+  }, [superPowerInfo])
 
   const startUsingSuperPower = () => {
     if (!superPowerCanBeUsed?.canBeUsed) {

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/RogueSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/RogueSuperPower.js
@@ -1,7 +1,48 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { EXPEDITION_STATUS } from '../../../../../../utils/constants'
+import SuperPowerTrigger from '../SuperPowerTrigger'
 
 function RogueSuperPower(props) {
-  return <div></div>
+  const [superPowerCanBeUsed, setSuperPowerCanBeUsed] = useState(undefined)
+  const [superPowerInfo, setSuperPowerInfo] = useState(undefined)
+
+  useEffect(() => {
+    if (props.status === EXPEDITION_STATUS.ANSWER) {
+      props
+        .useCheck()
+        .then((response) => {
+          setSuperPowerCanBeUsed(response)
+        })
+        .catch(() => {
+          setSuperPowerCanBeUsed(null)
+        })
+    } else {
+      setSuperPowerCanBeUsed({ canBeUsed: false, message: 'Moc nie może być użyta w wyborze pytania.' })
+    }
+  }, [props, superPowerInfo])
+
+  useEffect(() => {
+    if (superPowerInfo?.value) {
+      window.location.reload()
+    }
+  }, [props, superPowerInfo])
+
+  const startUsingSuperPower = () => {
+    if (!superPowerCanBeUsed?.canBeUsed) {
+      return
+    }
+
+    props
+      .usePower()
+      .then((response) => {
+        setSuperPowerInfo(response)
+      })
+      .catch(() => {
+        setSuperPowerInfo(null)
+      })
+  }
+
+  return <SuperPowerTrigger superPowerCanBeUsed={superPowerCanBeUsed} startSuperPower={startUsingSuperPower} />
 }
 
 export default RogueSuperPower

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/RogueSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/RogueSuperPower.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function RogueSuperPower(props) {
+  return <div></div>
+}
+
+export default RogueSuperPower

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/RogueSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/RogueSuperPower.js
@@ -1,31 +1,17 @@
 import React, { useState, useEffect } from 'react'
-import { EXPEDITION_STATUS } from '../../../../../../utils/constants'
 import SuperPowerTrigger from '../SuperPowerTrigger'
+import { useRogueSuperPowerCheck } from '../../../../../../hooks/useSuperPowerCheck'
 
 function RogueSuperPower(props) {
-  const [superPowerCanBeUsed, setSuperPowerCanBeUsed] = useState(undefined)
   const [superPowerInfo, setSuperPowerInfo] = useState(undefined)
 
-  useEffect(() => {
-    if (props.status === EXPEDITION_STATUS.ANSWER) {
-      props
-        .useCheck()
-        .then((response) => {
-          setSuperPowerCanBeUsed(response)
-        })
-        .catch(() => {
-          setSuperPowerCanBeUsed(null)
-        })
-    } else {
-      setSuperPowerCanBeUsed({ canBeUsed: false, message: 'Moc nie może być użyta w wyborze pytania.' })
-    }
-  }, [props, superPowerInfo])
+  const superPowerCanBeUsed = useRogueSuperPowerCheck(props.useCheck, superPowerInfo, props.status)
 
   useEffect(() => {
     if (superPowerInfo?.value) {
       window.location.reload()
     }
-  }, [props, superPowerInfo])
+  }, [superPowerInfo])
 
   const startUsingSuperPower = () => {
     if (!superPowerCanBeUsed?.canBeUsed) {

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WarriorSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WarriorSuperPower.js
@@ -1,7 +1,0 @@
-import React from 'react'
-
-function WarriorSuperPower(props) {
-  return <div></div>
-}
-
-export default WarriorSuperPower

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WarriorSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WarriorSuperPower.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function WarriorSuperPower(props) {
+  return <div></div>
+}
+
+export default WarriorSuperPower

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardAndWarriorSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardAndWarriorSuperPower.js
@@ -8,7 +8,7 @@ import { Button, Col, Row } from 'react-bootstrap'
 import { connect } from 'react-redux'
 
 // TODO: custom hook for all hero types for checking usage is possible
-function WizardSuperPower(props) {
+function WizardAndWarriorSuperPower(props) {
   const isExpanded = props.sidebar.isExpanded
 
   const [isShootingPanelDisplayed, setIsShootingPanelDisplayed] = useState(false)
@@ -37,7 +37,7 @@ function WizardSuperPower(props) {
        *   - generateDoor function has to display this value
        *   - after refreshing the page, we would lose this value and the power has already been used up
        */
-      localStorage.setItem('questionPoints', JSON.stringify({ id: chosenQuestionId, type: superPowerInfo.value }))
+      localStorage.setItem(props.storageKey, JSON.stringify({ id: chosenQuestionId, value: superPowerInfo.value }))
     }
   }, [chosenQuestionId, props, superPowerInfo])
 
@@ -88,4 +88,4 @@ function mapStateToProps(state) {
     theme
   }
 }
-export default connect(mapStateToProps)(WizardSuperPower)
+export default connect(mapStateToProps)(WizardAndWarriorSuperPower)

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardAndWarriorSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardAndWarriorSuperPower.js
@@ -1,35 +1,20 @@
 import React, { useState, useEffect } from 'react'
 import SuperPowerTrigger from '../SuperPowerTrigger'
-import { EXPEDITION_STATUS } from '../../../../../../utils/constants'
 import { ShootingPanel } from '../SuperPowerStyle'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowsToDot } from '@fortawesome/free-solid-svg-icons'
 import { Button, Col, Row } from 'react-bootstrap'
 import { connect } from 'react-redux'
+import { useQuestionInfoSuperPowerCheck } from '../../../../../../hooks/useSuperPowerCheck'
 
-// TODO: custom hook for all hero types for checking usage is possible
 function WizardAndWarriorSuperPower(props) {
   const isExpanded = props.sidebar.isExpanded
 
   const [isShootingPanelDisplayed, setIsShootingPanelDisplayed] = useState(false)
   const [chosenQuestionId, setChosenQuestionId] = useState(null)
-  const [superPowerCanBeUsed, setSuperPowerCanBeUsed] = useState(undefined)
   const [superPowerInfo, setSuperPowerInfo] = useState(undefined)
 
-  useEffect(() => {
-    if (props.status === EXPEDITION_STATUS.CHOOSE) {
-      props
-        .useCheck()
-        .then((response) => {
-          setSuperPowerCanBeUsed(response)
-        })
-        .catch(() => {
-          setSuperPowerCanBeUsed(null)
-        })
-    } else {
-      setSuperPowerCanBeUsed({ canBeUsed: false, message: 'Moc może być użyta tylko w wyborze pytania.' })
-    }
-  }, [props, superPowerInfo])
+  const superPowerCanBeUsed = useQuestionInfoSuperPowerCheck(props.useCheck, superPowerInfo, props.status)
 
   useEffect(() => {
     if (superPowerInfo?.value) {
@@ -39,7 +24,7 @@ function WizardAndWarriorSuperPower(props) {
        */
       localStorage.setItem(props.storageKey, JSON.stringify({ id: chosenQuestionId, value: superPowerInfo.value }))
     }
-  }, [chosenQuestionId, props, superPowerInfo])
+  }, [chosenQuestionId, props.storageKey, superPowerInfo])
 
   const startUsingSuperPower = () => {
     if (!superPowerCanBeUsed?.canBeUsed) {

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardSuperPower.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function WizardSuperPower(props) {
+  return <div></div>
+}
+
+export default WizardSuperPower

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardSuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/HeroSuperPower/WizardSuperPower.js
@@ -1,7 +1,91 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import SuperPowerTrigger from '../SuperPowerTrigger'
+import { EXPEDITION_STATUS } from '../../../../../../utils/constants'
+import { ShootingPanel } from '../SuperPowerStyle'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowsToDot } from '@fortawesome/free-solid-svg-icons'
+import { Button, Col, Row } from 'react-bootstrap'
+import { connect } from 'react-redux'
 
+// TODO: custom hook for all hero types for checking usage is possible
 function WizardSuperPower(props) {
-  return <div></div>
+  const isExpanded = props.sidebar.isExpanded
+
+  const [isShootingPanelDisplayed, setIsShootingPanelDisplayed] = useState(false)
+  const [chosenQuestionId, setChosenQuestionId] = useState(null)
+  const [superPowerCanBeUsed, setSuperPowerCanBeUsed] = useState(undefined)
+  const [superPowerInfo, setSuperPowerInfo] = useState(undefined)
+
+  useEffect(() => {
+    if (props.status === EXPEDITION_STATUS.CHOOSE) {
+      props
+        .useCheck()
+        .then((response) => {
+          setSuperPowerCanBeUsed(response)
+        })
+        .catch(() => {
+          setSuperPowerCanBeUsed(null)
+        })
+    } else {
+      setSuperPowerCanBeUsed({ canBeUsed: false, message: 'Moc może być użyta tylko w wyborze pytania.' })
+    }
+  }, [props, superPowerInfo])
+
+  useEffect(() => {
+    if (superPowerInfo?.value) {
+      /* We have to save question type in localStorage because:
+       *   - generateDoor function has to display this value
+       *   - after refreshing the page, we would lose this value and the power has already been used up
+       */
+      localStorage.setItem('questionPoints', JSON.stringify({ id: chosenQuestionId, type: superPowerInfo.value }))
+    }
+  }, [chosenQuestionId, props, superPowerInfo])
+
+  const startUsingSuperPower = () => {
+    if (!superPowerCanBeUsed?.canBeUsed) {
+      return
+    }
+    setIsShootingPanelDisplayed(true)
+  }
+
+  const showQuestionPoint = (questionId) => {
+    setChosenQuestionId(questionId)
+    props
+      .usePower(questionId)
+      .then((response) => {
+        setSuperPowerInfo(response)
+        setIsShootingPanelDisplayed(false)
+      })
+      .catch(() => {
+        setSuperPowerInfo(null)
+      })
+  }
+
+  return (
+    <>
+      <SuperPowerTrigger superPowerCanBeUsed={superPowerCanBeUsed} startSuperPower={startUsingSuperPower} />
+      <ShootingPanel style={{ display: isShootingPanelDisplayed ? 'flex' : 'none' }} $isExpanded={isExpanded}>
+        <Row className='m-0 justify-content-between w-100'>
+          {props.questions?.map((question) => (
+            <Col className={'text-center'} key={question.id}>
+              <FontAwesomeIcon icon={faArrowsToDot} onClick={() => showQuestionPoint(question.id)} />
+            </Col>
+          ))}
+        </Row>
+
+        <Button onClick={() => setIsShootingPanelDisplayed(false)}>Anuluj</Button>
+      </ShootingPanel>
+    </>
+  )
 }
 
-export default WizardSuperPower
+function mapStateToProps(state) {
+  const sidebar = state.sidebar
+  const theme = state.theme
+
+  return {
+    sidebar,
+    theme
+  }
+}
+export default connect(mapStateToProps)(WizardSuperPower)

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPower.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { HeroType } from '../../../../../utils/userRole'
+import ExpeditionService from '../../../../../services/expedition.service'
+import WizardSuperPower from './HeroSuperPower/WizardSuperPower'
+import WarriorSuperPower from './HeroSuperPower/WarriorSuperPower'
+import RogueSuperPower from './HeroSuperPower/RogueSuperPower'
+import PriestSuperPower from './HeroSuperPower/PriestSuperPower'
+
+function SuperPower(props) {
+  const userHeroType = localStorage.getItem('heroType')
+  const powerUse = (questionId = undefined) => ExpeditionService.startSuperPower(props.activityId, questionId)
+  const checkPowerCanBeUsed = () => ExpeditionService.checkSuperPowerCanBeUsed(props.activityId)
+
+  const contentMapper = {
+    [HeroType.WIZARD]: <WizardSuperPower status={props.status} usePower={powerUse} useCheck={checkPowerCanBeUsed} />,
+    [HeroType.WARRIOR]: <WarriorSuperPower status={props.status} usePower={powerUse} useCheck={checkPowerCanBeUsed} />,
+    [HeroType.ROGUE]: <RogueSuperPower status={props.status} usePower={powerUse} useCheck={checkPowerCanBeUsed} />,
+    [HeroType.PRIEST]: (
+      <PriestSuperPower setRemainingTime={props.setRemainingTime} usePower={powerUse} useCheck={checkPowerCanBeUsed} />
+    )
+  }
+
+  return contentMapper[userHeroType]
+}
+
+function mapStateToProps(state) {
+  const sidebar = state.sidebar
+  const theme = state.theme
+
+  return {
+    sidebar,
+    theme
+  }
+}
+
+export default connect(mapStateToProps)(SuperPower)

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPower.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import { HeroType } from '../../../../../utils/userRole'
 import ExpeditionService from '../../../../../services/expedition.service'
 import WizardSuperPower from './HeroSuperPower/WizardSuperPower'
@@ -13,8 +12,22 @@ function SuperPower(props) {
   const checkPowerCanBeUsed = () => ExpeditionService.checkSuperPowerCanBeUsed(props.activityId)
 
   const contentMapper = {
-    [HeroType.WIZARD]: <WizardSuperPower status={props.status} usePower={powerUse} useCheck={checkPowerCanBeUsed} />,
-    [HeroType.WARRIOR]: <WarriorSuperPower status={props.status} usePower={powerUse} useCheck={checkPowerCanBeUsed} />,
+    [HeroType.WIZARD]: (
+      <WizardSuperPower
+        status={props.status}
+        usePower={powerUse}
+        useCheck={checkPowerCanBeUsed}
+        questions={props.questions}
+      />
+    ),
+    [HeroType.WARRIOR]: (
+      <WarriorSuperPower
+        status={props.status}
+        usePower={powerUse}
+        useCheck={checkPowerCanBeUsed}
+        questions={props.questions}
+      />
+    ),
     [HeroType.ROGUE]: <RogueSuperPower status={props.status} usePower={powerUse} useCheck={checkPowerCanBeUsed} />,
     [HeroType.PRIEST]: (
       <PriestSuperPower setRemainingTime={props.setRemainingTime} usePower={powerUse} useCheck={checkPowerCanBeUsed} />
@@ -24,14 +37,4 @@ function SuperPower(props) {
   return contentMapper[userHeroType]
 }
 
-function mapStateToProps(state) {
-  const sidebar = state.sidebar
-  const theme = state.theme
-
-  return {
-    sidebar,
-    theme
-  }
-}
-
-export default connect(mapStateToProps)(SuperPower)
+export default SuperPower

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPower.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPower.js
@@ -1,33 +1,31 @@
 import React from 'react'
 import { HeroType } from '../../../../../utils/userRole'
 import ExpeditionService from '../../../../../services/expedition.service'
-import WizardSuperPower from './HeroSuperPower/WizardSuperPower'
-import WarriorSuperPower from './HeroSuperPower/WarriorSuperPower'
+
 import RogueSuperPower from './HeroSuperPower/RogueSuperPower'
 import PriestSuperPower from './HeroSuperPower/PriestSuperPower'
+import WizardAndWarriorSuperPower from './HeroSuperPower/WizardAndWarriorSuperPower'
 
 function SuperPower(props) {
   const userHeroType = localStorage.getItem('heroType')
   const powerUse = (questionId = undefined) => ExpeditionService.startSuperPower(props.activityId, questionId)
   const checkPowerCanBeUsed = () => ExpeditionService.checkSuperPowerCanBeUsed(props.activityId)
 
+  const wizardAndWarriorSuperPowerComponent = (storageKey) => {
+    return (
+      <WizardAndWarriorSuperPower
+        status={props.status}
+        usePower={powerUse}
+        useCheck={checkPowerCanBeUsed}
+        questions={props.questions}
+        storageKey={storageKey}
+      />
+    )
+  }
+
   const contentMapper = {
-    [HeroType.WIZARD]: (
-      <WizardSuperPower
-        status={props.status}
-        usePower={powerUse}
-        useCheck={checkPowerCanBeUsed}
-        questions={props.questions}
-      />
-    ),
-    [HeroType.WARRIOR]: (
-      <WarriorSuperPower
-        status={props.status}
-        usePower={powerUse}
-        useCheck={checkPowerCanBeUsed}
-        questions={props.questions}
-      />
-    ),
+    [HeroType.WIZARD]: wizardAndWarriorSuperPowerComponent('questionPoints'),
+    [HeroType.WARRIOR]: wizardAndWarriorSuperPowerComponent('questionType'),
     [HeroType.ROGUE]: <RogueSuperPower status={props.status} usePower={powerUse} useCheck={checkPowerCanBeUsed} />,
     [HeroType.PRIEST]: (
       <PriestSuperPower setRemainingTime={props.setRemainingTime} usePower={powerUse} useCheck={checkPowerCanBeUsed} />

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPowerStyle.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPowerStyle.js
@@ -32,3 +32,29 @@ export const SuperPowerButton = styled.div`
     bottom: 85px;
   }
 `
+
+export const ShootingPanel = styled.div`
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: ${(props) => (props.$isExpanded ? 'calc(100vw - 330px)' : 'calc(100vw - 55px)')};
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.4);
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  & svg {
+    font-size: 128px;
+    color: white;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  & button {
+    position: absolute;
+    bottom: 20px;
+  }
+`

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPowerStyle.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPowerStyle.js
@@ -1,0 +1,34 @@
+import styled from 'styled-components'
+
+export const SuperPowerButton = styled.div`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: ${(props) => props.$color};
+  opacity: ${(props) => (props.$isBlocked ? 0.7 : 1)};
+  border: 1px solid ${(props) => props.$color};
+  position: fixed;
+  left: ${(props) => (props.$isExpanded ? '340px' : '70px')};
+  bottom: 10px;
+  z-index: 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &:hover {
+    cursor: ${(props) => (props.$isBlocked ? 'default' : 'pointer')};
+  }
+
+  & svg {
+    transition: all 0.2s linear;
+    color: white;
+  }
+
+  &:hover svg {
+    transform: ${(props) => (props.$isBlocked ? `scale(1)` : `scale(1.5)`)};
+  }
+
+  @media (max-width: 575px) {
+    bottom: 85px;
+  }
+`

--- a/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPowerTrigger.js
+++ b/frontend/src/components/student/AllActivities/ExpeditionTask/SuperPower/SuperPowerTrigger.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faBolt } from '@fortawesome/free-solid-svg-icons'
+import Tooltip from '../../../../general/Tooltip/Tooltip'
+import { connect } from 'react-redux'
+import { SuperPowerButton } from './SuperPowerStyle'
+
+function SuperPowerTrigger(props) {
+  const isSidebarExpanded = props.sidebar.isExpanded
+  const superPowerCanBeUsed = props.superPowerCanBeUsed
+
+  return (
+    <>
+      <SuperPowerButton
+        data-for={'super-power-trigger'}
+        data-tip={superPowerCanBeUsed?.message ?? ''}
+        $isBlocked={!superPowerCanBeUsed?.canBeUsed}
+        $isExpanded={isSidebarExpanded}
+        $color={props.theme.success}
+        onClick={props.startSuperPower}
+      >
+        <FontAwesomeIcon icon={faBolt} />
+      </SuperPowerButton>
+
+      <Tooltip id={'super-power-trigger'} />
+    </>
+  )
+}
+
+function mapStateToProps(state) {
+  const sidebar = state.sidebar
+  const theme = state.theme
+
+  return {
+    sidebar,
+    theme
+  }
+}
+
+export default connect(mapStateToProps)(SuperPowerTrigger)

--- a/frontend/src/components/student/BadgesPage/BadgesPage.js
+++ b/frontend/src/components/student/BadgesPage/BadgesPage.js
@@ -13,8 +13,8 @@ import { base64Header, ERROR_OCCURRED } from '../../../utils/constants'
 import { isMobileView } from '../../../utils/mobileHelper'
 import UserService from '../../../services/user.service'
 import { sortArray } from '../../general/Ranking/sortHelper'
-import ReactTooltip from 'react-tooltip'
 import moment from 'moment'
+import Tooltip from '../../general/Tooltip/Tooltip'
 
 const LATER_ITEM_DELAY = 1200
 
@@ -121,15 +121,7 @@ function BadgesPage(props) {
             {badge.description}
           </p>
 
-          <ReactTooltip
-            id={'badge-' + index}
-            place='top'
-            type='dark'
-            effect='solid'
-            multiline
-            event='mouseover mouseenter'
-            eventOff='mouseleave mouseout scroll mousewheel blur'
-          />
+          <Tooltip id={'badge-' + index} />
         </Col>
       )
     },

--- a/frontend/src/components/student/GameCardPage/GameCardView.js
+++ b/frontend/src/components/student/GameCardPage/GameCardView.js
@@ -20,7 +20,10 @@ function GameCardView(props) {
 
   useEffect(() => {
     StudentService.getDashboardStats()
-      .then((response) => setDashboardStats(response))
+      .then((response) => {
+        setDashboardStats(response)
+        localStorage.setItem('heroType', response.heroTypeStats.heroType)
+      })
       .catch(() => setDashboardStats(null))
   }, [])
 

--- a/frontend/src/hooks/useSuperPowerCheck.js
+++ b/frontend/src/hooks/useSuperPowerCheck.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { EXPEDITION_STATUS } from '../utils/constants'
+
+export const useSuperPowerCheck = (checkFunction, superPowerInfo, skip = false, onSkipObject = undefined) => {
+  const [superPowerCanBeUsed, setSuperPowerCanBeUsed] = useState(undefined)
+
+  useEffect(() => {
+    if (!skip) {
+      checkFunction()
+        .then((response) => {
+          setSuperPowerCanBeUsed(response)
+        })
+        .catch(() => {
+          setSuperPowerCanBeUsed(null)
+        })
+    } else {
+      setSuperPowerCanBeUsed(onSkipObject)
+    }
+
+    // eslint-disable-next-line
+  }, [superPowerInfo, skip])
+
+  return superPowerCanBeUsed
+}
+
+export const useRogueSuperPowerCheck = (checkFunction, superPowerInfo, status) => {
+  const onSkipObject = { canBeUsed: false, message: 'Moc nie może być użyta w wyborze pytania.' }
+  const skip = status !== EXPEDITION_STATUS.ANSWER
+
+  return useSuperPowerCheck(checkFunction, superPowerInfo, skip, onSkipObject)
+}
+
+export const useQuestionInfoSuperPowerCheck = (checkFunction, superPowerInfo, status) => {
+  const onSkipObject = { canBeUsed: false, message: 'Moc może być użyta tylko w wyborze pytania.' }
+  const skip = status !== EXPEDITION_STATUS.CHOOSE
+
+  return useSuperPowerCheck(checkFunction, superPowerInfo, skip, onSkipObject)
+}

--- a/frontend/src/services/auth.service.js
+++ b/frontend/src/services/auth.service.js
@@ -23,6 +23,7 @@ class AuthService {
 
   logout() {
     localStorage.removeItem('user')
+    localStorage.removeItem('heroType')
   }
 
   register({ firstName, lastName, email, password, accountType, heroType, index, token }) {

--- a/frontend/src/services/auth.service.js
+++ b/frontend/src/services/auth.service.js
@@ -24,6 +24,8 @@ class AuthService {
   logout() {
     localStorage.removeItem('user')
     localStorage.removeItem('heroType')
+    localStorage.removeItem('questionPoints')
+    localStorage.removeItem('questionType')
   }
 
   register({ firstName, lastName, email, password, accountType, heroType, index, token }) {

--- a/frontend/src/services/expedition.service.js
+++ b/frontend/src/services/expedition.service.js
@@ -12,7 +12,9 @@ import {
   GET_TASK_GRAPH_RESULT_POINTS_AVAILABLE_CLOSED,
   GET_TASK_GRAPH_RESULT_POINTS_AVAILABLE_OPENED,
   GET_TASK_GRAPH_CREATE,
-  POST_TASK_GRAPH_CREATE
+  POST_TASK_GRAPH_CREATE,
+  GET_TASK_GRAPH_RESULT_SUPER_POWER_CAN_USE,
+  GET_TASK_GRAPH_RESULT_SUPER_POWER
 } from './urls'
 
 class ExpeditionService {
@@ -109,6 +111,21 @@ class ExpeditionService {
     return axiosApiPost(POST_TASK_GRAPH_CREATE, {
       chapterId: chapterId,
       form: form
+    }).catch((error) => {
+      throw error
+    })
+  }
+
+  checkSuperPowerCanBeUsed(graphTaskId) {
+    return axiosApiGet(GET_TASK_GRAPH_RESULT_SUPER_POWER_CAN_USE, { graphTaskId }).catch((error) => {
+      throw error
+    })
+  }
+
+  useSuperPower(graphTaskId, questionId = undefined) {
+    return axiosApiGet(GET_TASK_GRAPH_RESULT_SUPER_POWER, {
+      graphTaskId,
+      questionId
     }).catch((error) => {
       throw error
     })

--- a/frontend/src/services/expedition.service.js
+++ b/frontend/src/services/expedition.service.js
@@ -90,7 +90,7 @@ class ExpeditionService {
   }
 
   getCurrentState(activityId) {
-    return axiosApiGet(GET_QUESTION_INFO, { graphTaskId: activityId }).catch((error) => {
+    return axiosApiGet(GET_QUESTION_INFO, { graphTaskId: activityId }, true).catch((error) => {
       throw error
     })
   }

--- a/frontend/src/services/expedition.service.js
+++ b/frontend/src/services/expedition.service.js
@@ -122,7 +122,7 @@ class ExpeditionService {
     })
   }
 
-  useSuperPower(graphTaskId, questionId = undefined) {
+  startSuperPower(graphTaskId, questionId = undefined) {
     return axiosApiGet(GET_TASK_GRAPH_RESULT_SUPER_POWER, {
       graphTaskId,
       questionId

--- a/frontend/src/services/professor.service.js
+++ b/frontend/src/services/professor.service.js
@@ -1,5 +1,12 @@
 import { parseJwt } from '../utils/Api'
-import { axiosApiGet, axiosApiGetFile, axiosApiPost, axiosApiMultipartPost, axiosApiDelete } from '../utils/axios'
+import {
+  axiosApiGet,
+  axiosApiGetFile,
+  axiosApiPost,
+  axiosApiMultipartPost,
+  axiosApiDelete,
+  axiosApiPut
+} from '../utils/axios'
 import {
   POST_TASK_RESULT_CSV,
   GET_TASK_EVALUATE_ALL,
@@ -11,7 +18,8 @@ import {
   GET_PROFESSOR_REGISTER_TOKEN,
   GET_GRADES,
   DELETE_USER_PROFESSOR,
-  GET_PROFESSOR_EMAILS
+  GET_PROFESSOR_EMAILS,
+  PUT_HERO
 } from './urls'
 
 class ProfessorService {
@@ -98,6 +106,16 @@ class ProfessorService {
 
   getProfessorsEmails() {
     return axiosApiGet(GET_PROFESSOR_EMAILS).catch((error) => {
+      throw error
+    })
+  }
+
+  editHeroSuperPower(heroType, powerBaseValue, coolDownMs) {
+    return axiosApiPut(PUT_HERO, {
+      type: heroType,
+      value: powerBaseValue,
+      coolDownMillis: coolDownMs
+    }).catch((error) => {
       throw error
     })
   }

--- a/frontend/src/services/urls.js
+++ b/frontend/src/services/urls.js
@@ -59,6 +59,8 @@ export const GET_TASK_GRAPH_RESULT_POINTS_AVAILABLE_OPENED = GET_TASK_GRAPH_RESU
 export const GET_TASK_GRAPH_RESULT_POINTS_AVAILABLE_CLOSED = GET_TASK_GRAPH_RESULT + '/points/available/closed'
 export const GET_TASK_GRAPH_RESULT_POINTS_AVAILABLE_ALL = GET_TASK_GRAPH_RESULT + '/points/available/all'
 export const GET_TASK_GRAPH_RESULT_POINTS_ALL = GET_TASK_GRAPH_RESULT + '/points/all'
+export const GET_TASK_GRAPH_RESULT_SUPER_POWER = GET_TASK_GRAPH_RESULT + '/super-power'
+export const GET_TASK_GRAPH_RESULT_SUPER_POWER_CAN_USE = GET_TASK_GRAPH_RESULT + 'super-power/can-use'
 
 // Graph Task Controller
 export const GET_TASK_GRAPH = BASE_URL + '/task/graph'
@@ -166,3 +168,6 @@ export const PUT_BADGE_UPDATE = BADGE + '/update'
 
 // Grade Controller
 export const GET_GRADES = BASE_URL + '/grades'
+
+// Hero Controller
+export const PUT_HERO = BASE_URL + '/hero'

--- a/frontend/src/services/urls.js
+++ b/frontend/src/services/urls.js
@@ -60,7 +60,7 @@ export const GET_TASK_GRAPH_RESULT_POINTS_AVAILABLE_CLOSED = GET_TASK_GRAPH_RESU
 export const GET_TASK_GRAPH_RESULT_POINTS_AVAILABLE_ALL = GET_TASK_GRAPH_RESULT + '/points/available/all'
 export const GET_TASK_GRAPH_RESULT_POINTS_ALL = GET_TASK_GRAPH_RESULT + '/points/all'
 export const GET_TASK_GRAPH_RESULT_SUPER_POWER = GET_TASK_GRAPH_RESULT + '/super-power'
-export const GET_TASK_GRAPH_RESULT_SUPER_POWER_CAN_USE = GET_TASK_GRAPH_RESULT + 'super-power/can-use'
+export const GET_TASK_GRAPH_RESULT_SUPER_POWER_CAN_USE = GET_TASK_GRAPH_RESULT + '/super-power/can-use'
 
 // Graph Task Controller
 export const GET_TASK_GRAPH = BASE_URL + '/task/graph'

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -13,12 +13,14 @@ export function axiosApiPost(url, body) {
     })
 }
 
-export function axiosApiGet(url, params) {
+export function axiosApiGet(url, params, hideToast = false) {
   return axios
     .get(url, validHeader(params))
     .then((response) => response.data)
     .catch((error) => {
-      errorToast(error?.response?.data?.message)
+      if (!hideToast) {
+        errorToast(error?.response?.data?.message)
+      }
       throw error
     })
 }

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -269,3 +269,25 @@ export const BadgeType = {
 }
 
 export const sidebarExcludedPaths = [GeneralRoutes.HOME, GeneralRoutes.PASSWORD_RESET]
+
+export const getSpecifyDescription = (heroType) => {
+  const baseInfo = `Wartość mocy postaci na poziomie 1. <br/> Dla wybranej postaci: ${getHeroName(
+    heroType
+  )} wartość ta oznacza <br/>`
+
+  const MAX_NUMBER_OF_USAGE = 'maksymalną liczbę możliwych wykorzystań umiejętności w jednej ekspedycji.'
+
+  const heroTypeSuperPowerDescription = {
+    [HeroType.PRIEST]: 'liczbę ms o jaką gracz wydłuży sobie czas. Umiejętność jest dostępna raz na ekspedycję.',
+    [HeroType.ROGUE]:
+      'maksymalną liczbę punktów, którą może mieć zadanie, aby gracz mógł je pominąć. Umiejętność jest dostępna raz na ekspedycję.',
+    [HeroType.WARRIOR]: MAX_NUMBER_OF_USAGE,
+    [HeroType.WIZARD]: MAX_NUMBER_OF_USAGE
+  }
+
+  return baseInfo + heroTypeSuperPowerDescription[heroType]
+}
+
+export const coolDownDescription = (heroType) =>
+  `Wartość ta (podana w minutach) oznacza po jakim czasie bohater o wybranym typie: ${getHeroName(heroType)} <br/> 
+   będzie mógł użyć swojej mocy ponownie w tej samej ekspedycji.`

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -126,19 +126,16 @@ export const RegistrationLabelsAndTypes = {
 
 export const HeroDescriptions = {
   [HeroType.WARRIOR]: `Skupiony na zdolnościach walki, całkowicie pozbawiony magicznych zdolności. 
-            Łatwiej mu pokonać trudnego przeciwnika (daje raz w miesiącu możliwość podmiany 
-            treści pytania trudnego na treść pytania łatwego w ekspedycji bez zmiany ilości puntków za zadanie).
-            W karcie gry widzisz informację, na którym miejscu w rankingu się znajdujesz.`,
-  [HeroType.WIZARD]: `Przejawiający zdolności magiczne, lecz fizycznie słaby. Dzięki swoim czarom może cofnąć się w grafie
-            ekspedycji do wyboru pytania (anulować ostatni wybór) i wybrać inne (umiejętność dostępna raz na miesiąc).
-            W karcie gry widzisz informację, na którym miejscu w rankingu się znajdujesz.`,
-  [HeroType.PRIEST]: `Specjalizujący się w uzdrawianiu. Dzięki swoim umiejętnościom uzdrawiania może dodać sobie 5pkt po zakończeniu
-            ekspedycji. Umiejętność ta jest dostępna raz w miesiącu. W karcie gry widzisz informację jaki % graczy jest
-            lepszych od Ciebie i od jakiego % graczy Ty jesteś wyżej w rankingu.`,
+            Łatwiej mu pokonać trudnego przeciwnika. Pozwala na odkrycie typu pytania kilka razy w jednej ekspedycji (umiejętność dostępna raz na tydzień).
+            W karcie gry widzisz informację, na którym miejscu w rankingu się znajdujesz oraz porównanie z osobą przed Tobą i za Tobą w rankingu.`,
+  [HeroType.WIZARD]: `Przejawiający zdolności magiczne, lecz fizycznie słaby. Dzięki swoim czarom może kilka razy w jednek ekspedycji
+            poznać punktację dowolnego pytania przed przejściem do tego pytania (umiejętność dostępna raz na tydzień).
+            W karcie gry widzisz informację w jakim % graczy się znajdujesz.`,
+  [HeroType.PRIEST]: `Specjalizujący się w uzdrawianiu. Dzięki swoim umiejętnościom uzdrawiania może jednorazowo w ekspedycji wydłużyć czas jej trwania 
+            (umiejętność dostępna raz na tydzień). W karcie gry widzisz informację w jakim % graczy się znajdujesz.`,
   [HeroType.ROGUE]: `Potrafi poruszać się bezszelestnie, skradanie to jego dominująca umiejętność. Dzięki swoim zdolnościom 
-            umożliwi Ci pominąć jedno pytanie w ekspedycji na poziomie łatwym warte nie więcej niż 5pkt. Umiejętność
-            ta jest dostępna raz w miesiącu. W karcie gry widzisz informację jaki % graczy jest
-            lepszych od Ciebie i od jakiego % graczy Ty jesteś wyżej w rankingu.`
+            umożliwi Ci pominąć jedno pytanie w ekspedycji na poziomie łatwym warte nie więcej niż 5pkt. 
+            W karcie gry widzisz informację, na którym miejscu w rankingu się znajdujesz oraz porównanie z osobą przed Tobą i za Tobą w rankingu.`
 }
 
 export const HeroImg = {

--- a/frontend/src/utils/sidebarTitles.js
+++ b/frontend/src/utils/sidebarTitles.js
@@ -88,7 +88,7 @@ export const ProfessorSidebarTitles = [
         navigateTo: TeacherRoutes.GAME_MANAGEMENT.RANKS_AND_BADGES
       },
       {
-        name: 'Temat gry',
+        name: 'Ustawienia gry',
         icon: faPalette,
         navigateTo: TeacherRoutes.GAME_MANAGEMENT.GAME_SETTINGS
       }


### PR DESCRIPTION
W zależności od typu postaci mamy inne umiejętności. Wymieńmy raz jeszcze:
* Kapłan (PRIEST) - możliwość dodania sobie dodatkowego czasu raz na ekspedycję w dowolnym momencie
* Łotrzyk (ROGUE) - możliwość pominięcia jednego pytania na całą ekspedycję, które ma mniej niż X punktów (gdzie X jest zależne od rangi postaci). Moc ta ma sens wykorzystania tylko gdy jesteśmy wewnątrz pytania.
* Wojownik (WARRIOR) - może kilka razy w ekspedycji sprawdzić jakiego typu jest pojedyncze pytanie. Moc ma sens tylko w momencie wyboru spośród pytań.
* Czarodziej (WIZARD) - może kilka razy w ekspedycji sprawdzić za ile punktów jest wybrane pytanie. Moc ma sens tylko w momencie wyboru spośród pytań.

### Zadania w tym tasku:
1. Podczepienie endpointa do używania umiejętności: 
`GET localhost:8080/api/task/graph/result/super-power?graphTaskId=1&questionId=2`
    * `questionId` jest opcjonalne wymagane tylko dla czarodzieja i wojownika
    * Response dla kapłana to nowy czas, który trzeba zaktualizować. Po użyciu następuje blokada buttona używania mocy.
    * Response dla łotrzyka to informacja czy udało się pominąć pytanie. Tutaj wystarczy tylko przeładować stronę ze względu na serwer side. Po użyciu blokujemy button używania mocy.
    * Response dla wojownika to typ pytania, o które pytał. Trzeba wyświetlić ten typ w pobliżu drzwi, których dotyczy. Ta moc jest używana wielokrotnie, więc trzeba pytać po przeładowaniu strony czy można użyć mocy. Jeżeli nie to button jest zablokowany z tooltipem.
    * Dla czarodzieja analogicznie jak dla wojownika, tylko dostajemy ilość punktów.

2. Podczepienie endpointa informującego czy można użyć mocy:
`GET localhost:8080/api/task/graph/result/super-power/use?graphTaskId=1`
    * Jeżeli można to button jest dostępny. Jeżeli nie można to jest zablokowany, a tooltip na nim wyświetla zwróconą informację o przyczynie.

3. Podczepienie endpointa do edycji umiejętności bohatera po stronie prowadzącego: 
`PUT localhost:8080/api/hero`
    * Dodać tę opcję w widoku “Temat gry” - modal z następującymi polami:
           * select z wyborem bohatera dla którego robimy edycję
           * wartość podstawowa mocy -> input typu number
           * Cooldown - pole pojawiające się tylko przy wyborze wojownika lub czarodzieja → input number w minutach i konwertowanie na ms

## Realizacja
1. Zmieniłem opisy bohaterów w rejestracji
2. Podczepiłem moce zgodnie z opisem wyżej. Dla wojownika i czarodzieja dodałem coś co nazwałem "ShootingPanel" (nie znalazłem fajniejszej ikony, jakbyś @kwdrt znalazł lepszą to chętnie podmienię)
3. Przy okazji naprawiłem problem z errorem przy przeładowaniu strony w ekspedycji (po prostu pozwalamy na 404 za pierwszym razem pobierając info, ale ukrywamy tooltip)
4. Dodałem edycję mocy po stronie prowadzącego